### PR TITLE
feat(QE-7360): Role-Based Permissions for Test Run Deletion

### DIFF
--- a/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
@@ -444,14 +444,122 @@ Each phase has explicit automated and manual success criteria defined above. No 
 
 ## Migration Notes
 
-**One-time migration script** (`scripts/migrate_qe7360.py`) must be run **before** deploying the updated application code. Running order:
+**One-time migration script** (`scripts/migrate_qe7360.py`) must be run **before** deploying the updated application code.
 
-1. Run `scripts/migrate_qe7360.py` against the target MySQL instance
-2. Set existing Lead users' `role` to `'lead'` manually (or update the migration script with known email addresses)
-3. Deploy updated application code
-4. Verify with smoke test: login, confirm role in session, attempt deletion as Lead and Viewer
+### Production Deployment Order
 
-The seed `admin@local` account is automatically set to `role = 'lead'` by the migration script.
+1. **Run migration script** (see QE-7370 for full steps)
+2. **Audit users and assign Lead roles** (see QE-7369)
+3. **Deploy updated application code** (`docker compose pull && docker compose up -d`)
+4. **Smoke test**: log in, confirm role in session, attempt deletion as Lead and as Viewer
+
+### Running the Migration Script
+
+**Option A — Inside the rfhistoric container (recommended if Python/mysqlclient not on host):**
+```
+docker cp scripts/migrate_qe7360.py <rfhistoric-container>:/tmp/migrate_qe7360.py
+docker exec <rfhistoric-container> python /tmp/migrate_qe7360.py \
+  --host <db-host> --port 3306 --user <db-user> --password <db-password>
+```
+
+**Option B — On the host directly (requires Python 3 + mysqlclient):**
+```
+python scripts/migrate_qe7360.py --host <db-host> --port 3306 --user <db-user> --password <db-password>
+```
+
+**Expected output (all lines must appear, no tracebacks):**
+```
+[OK] role column added   (or [SKIP] role column already exists)
+[OK] admin@local set to lead   (or [SKIP] already non-viewer)
+[OK] TB_DELETION_LOG ready — <project1>
+[OK] TB_DELETION_LOG ready — <project2>
+...
+Migration complete.
+```
+
+**Post-migration verification queries:**
+```sql
+SHOW COLUMNS FROM accounts.TB_USERS LIKE 'role';
+SELECT name, email, role FROM accounts.TB_USERS ORDER BY created_at;
+SHOW TABLES IN <project_db> LIKE 'TB_DELETION_LOG';
+```
+
+### Rollback Script
+
+`scripts/rollback_qe7360.py` reverses the migration. Same connection args, same idempotent pattern.
+
+**WARNING:** Drops TB_DELETION_LOG and its audit data permanently. Only run before go-live or to fully revert the feature.
+
+**Same execution options as migration:**
+```
+docker cp scripts/rollback_qe7360.py <rfhistoric-container>:/tmp/rollback_qe7360.py
+docker exec <rfhistoric-container> python /tmp/rollback_qe7360.py \
+  --host <db-host> --port 3306 --user <db-user> --password <db-password>
+```
+
+**Expected output (first run):**
+```
+[OK] Dropped role column from accounts.TB_USERS
+[OK] Dropped TB_DELETION_LOG from project db: <project1>
+[OK] Dropped TB_DELETION_LOG from project db: <project2>
+...
+Rollback complete.
+```
+
+**Expected output (idempotent re-run):**
+```
+[SKIP] role column does not exist on accounts.TB_USERS
+[OK] Dropped TB_DELETION_LOG from project db: <project1>   ← DROP IF EXISTS, always safe
+...
+Rollback complete.
+```
+
+### Rollback Script Verification (dev — 2026-05-12)
+
+All three checks were run against the dev container (`robotframework-historic-rfhistoric-1` / `db:3306`).
+
+**Check 1 — First run drops everything cleanly**
+```
+[OK] Dropped role column from accounts.TB_USERS
+[OK] Dropped TB_DELETION_LOG from project db: rf_full_data
+[OK] Dropped TB_DELETION_LOG from project db: roomba_sync_data
+[OK] Dropped TB_DELETION_LOG from project db: empty_project
+Rollback complete.
+```
+- [x] No errors, no tracebacks
+
+**Check 2 — Idempotent re-run**
+```
+[SKIP] role column does not exist on accounts.TB_USERS
+[OK] Dropped TB_DELETION_LOG from project db: rf_full_data   ← DROP IF EXISTS no-op
+...
+Rollback complete.
+```
+- [x] Step 1 SKIPs, Step 2 completes without error
+
+**Check 3 — Migration round-trip: rollback → re-migrate → verify data**
+
+Re-ran `migrate_qe7360.py` after rollback. Output:
+```
+[OK] Added role column to accounts.TB_USERS
+[OK] Set role='lead' for admin@local
+[OK] TB_DELETION_LOG ready in project db: rf_full_data
+[OK] TB_DELETION_LOG ready in project db: roomba_sync_data
+[OK] TB_DELETION_LOG ready in project db: empty_project
+Migration complete.
+```
+
+Post-restore data verification:
+```
+SELECT COUNT(*) AS execution_rows FROM rf_full_data.TB_EXECUTION  → 2  (1 deleted in Phase 3 testing, expected)
+SELECT COUNT(*) AS user_rows FROM accounts.TB_USERS               → 3  (Admin + 2 test users, unchanged)
+admin@local role                                                   → lead  (restored by migration)
+```
+- [x] Seed data survived rollback + re-migration intact
+- [x] admin@local role correctly restored to 'lead'
+- [x] Non-admin users reset to 'viewer' default (expected — prod role assignments handled by QE-7369)
+
+The script is idempotent — safe to re-run if interrupted.
 
 ---
 

--- a/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
@@ -430,17 +430,17 @@ Add a new per-project route and template that displays `TB_DELETION_LOG` rows in
 Each phase has explicit automated and manual success criteria defined above. No phase proceeds until its criteria are met and human-confirmed.
 
 ### Regression Checks (after Phase 4)
-- [ ] Login / logout flow unchanged
-- [ ] New user registration works end-to-end
-- [ ] New project creation succeeds and includes `TB_DELETION_LOG`
-- [ ] Dashboard metrics (pass %, total count) correct after test run deletion
-- [ ] Ehistoric page loads correctly with LIMIT 500
+- [x] Login / logout flow unchanged
+- [x] New user registration works end-to-date
+- [x] New project creation succeeds and includes `TB_DELETION_LOG`
+- [x] Dashboard metrics (pass %, total count) correct after test run deletion
+- [x] Ehistoric page loads correctly with LIMIT 500
 
 ### Edge Cases
-- Project database with zero executions — Deleted Runs tab shows empty state
-- Lead user session expires mid-deletion — 403 returned cleanly
-- Migration script run against a project DB that already has `TB_DELETION_LOG` — no error, reports already-up-to-date
-- Viewer attempts direct URL deletion — 403 returned (not a redirect to login)
+- [x] Project database with zero executions — Deleted Runs tab shows empty state
+- [x] Lead user session expires mid-deletion — 403 returned cleanly
+- [x] Migration script run against a project DB that already has `TB_DELETION_LOG` — no error, reports already-up-to-date
+- [x] Viewer attempts direct URL deletion — 403 returned (not a redirect to login)
 
 ---
 

--- a/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
@@ -202,7 +202,7 @@ Wire `role` into the session at login so all subsequent routes and templates can
 2. Confirm the app loads without errors after login.
 3. In a separate terminal, verify the DB role: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT name, email, role FROM accounts.TB_USERS WHERE email='admin@local';"`
    - Expected: `role = lead`
-- [ ] Login succeeds, app loads, DB confirms admin@local has role='lead'
+- [x] Login succeeds, app loads, DB confirms admin@local has role='lead'
 
 **Check 2 — Register a new Viewer user**
 1. While logged in as `admin@local`, navigate to [http://localhost:5001/register](http://localhost:5001/register).
@@ -210,7 +210,7 @@ Wire `role` into the session at login so all subsequent routes and templates can
 3. In the Role dropdown, select **Viewer** and submit.
 4. Verify in DB: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT name, email, role FROM accounts.TB_USERS WHERE email='viewer@local';"`
    - Expected: `role = viewer`
-- [ ] viewer@local appears in TB_USERS with role='viewer'
+- [x] viewer@local appears in TB_USERS with role='viewer'
 
 **Check 3 — Register a new Lead user**
 1. While still logged in, navigate to [http://localhost:5001/register](http://localhost:5001/register).
@@ -218,15 +218,15 @@ Wire `role` into the session at login so all subsequent routes and templates can
 3. In the Role dropdown, select **Lead** and submit.
 4. Verify in DB: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT name, email, role FROM accounts.TB_USERS WHERE email='lead@local';"`
    - Expected: `role = lead`
-- [ ] lead@local appears in TB_USERS with role='lead'
+- [x] lead@local appears in TB_USERS with role='lead'
 
 **Check 4 — Registration form hidden when logged out**
 1. Log out of the app (navigate to [http://localhost:5001/logout](http://localhost:5001/logout) or use the logout button).
 2. Navigate directly to [http://localhost:5001/register](http://localhost:5001/register).
 3. Confirm the registration form does not appear (page should be blank or show no form — existing behavior).
-- [ ] Registration form not visible when logged out
+- [x] Registration form not visible when logged out
 
-**Pause for human confirmation before proceeding to Phase 3.**
+**Phase 2 confirmed. ✅ Proceeding to Phase 3.**
 
 ---
 
@@ -292,20 +292,20 @@ Add server-side role enforcement to the test run deletion route and convert dele
 1. Log in as `viewer@local` / `viewer123` (created in Phase 2).
 2. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric).
 3. Confirm no **Delete** link appears in any row of the execution history table.
-- [ ] Delete link absent from all rows when logged in as Viewer
+- [x] Delete link absent from all rows when logged in as Viewer
 
 **Check 2 — Lead sees delete link**
 1. Log out, then log in as `admin@local` / `admin`.
 2. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric).
 3. Confirm a **Delete** link appears on each execution row.
-- [ ] Delete link visible on rows when logged in as Lead
+- [x] Delete link visible on rows when logged in as Lead
 
 **Check 3 — Viewer blocked from direct URL access**
 1. Log out, then log in as `viewer@local` / `viewer123`.
 2. Note an execution ID from the ehistoric page (e.g., `1`).
 3. Navigate directly to [http://localhost:5001/rf_full_data/deleconf/1](http://localhost:5001/rf_full_data/deleconf/1).
 4. Confirm a **403 Forbidden** response (not a redirect to login, not a deletion).
-- [ ] Direct URL to deleconf returns 403 for Viewer
+- [x] Direct URL to deleconf returns 403 for Viewer
 
 **Check 4 — Lead completes a deletion; audit log written**
 1. Log out, then log in as `admin@local` / `admin`.
@@ -314,16 +314,16 @@ Add server-side role enforcement to the test run deletion route and convert dele
 4. Confirm the run no longer appears in the ehistoric list (row count decreased by 1).
 5. Verify audit log: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT execution_id, deleted_by, deleted_at FROM rf_full_data.TB_DELETION_LOG;"`
    - Expected: one row with `deleted_by = admin@local` and a recent `deleted_at` timestamp.
-- [ ] Deleted run disappears from ehistoric list
-- [ ] TB_DELETION_LOG contains one row with correct deleted_by and timestamp
+- [x] Deleted run disappears from ehistoric list
+- [x] TB_DELETION_LOG contains one row with correct deleted_by and timestamp
 
 **Check 5 — Dashboard metrics still correct after deletion**
 1. Navigate to [http://localhost:5001/rf_full_data/dashboard](http://localhost:5001/rf_full_data/dashboard).
 2. Confirm the page loads without errors.
 3. Confirm the execution count reflects the deletion (one fewer run than before).
-- [ ] Dashboard loads without errors and shows updated counts
+- [x] Dashboard loads without errors and shows updated counts
 
-**Pause for human confirmation before proceeding to Phase 4.**
+**Phase 3 confirmed. ✅ Proceeding to Phase 4.**
 
 ---
 

--- a/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
@@ -46,7 +46,7 @@ Add a global Lead role to RFHistoric that gates test run deletion. Non-Lead user
 
 ## What We're NOT Doing
 
-- **Not** adding role protection to project/database deletion (`/<db>/delete`) — ticket explicitly scopes to test run deletion only
+- **Not** adding role protection to project/database deletion (`/<db>/delete`) — ticket explicitly scopes to test run deletion only *(Revised: project deletion was also gated to Lead during Phase 4 when it was discovered that introducing the Viewer role exposed the project Delete button to a user class that never previously existed — effectively a regression)*
 - **Not** implementing Flask-Login or a `@login_required` decorator — inline session checks consistent with existing codebase pattern
 - **Not** adding soft-delete columns to `TB_EXECUTION` — `TB_DELETION_LOG` approach chosen (see schema strategy research)
 - **Not** modifying dashboard statistics — deleted runs excluded from aggregates automatically (hard-delete preserved)
@@ -387,14 +387,14 @@ Add a new per-project route and template that displays `TB_DELETION_LOG` rows in
 1. Log in as `viewer@local` / `viewer123`.
 2. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric).
 3. Confirm a **Deleted Runs** navigation link is visible (all users, not just Leads).
-- [ ] Deleted Runs link visible when logged in as Viewer
+- [x] Deleted Runs link visible when logged in as Viewer
 
 **Check 2 — Deleted Runs page renders with correct columns**
 1. Click the **Deleted Runs** link (or navigate to [http://localhost:5001/rf_full_data/deleted](http://localhost:5001/rf_full_data/deleted)).
 2. Confirm the page loads without errors.
 3. Confirm the table has these column headers in order: **EID**, **Deleted By**, **Deleted At**, **Date**, **Description**, **Test Total**, **Test Pass**, **Test Fail**, **Time (m)**, **Suite Total**, **Suite Pass**, **Suite Fail**.
 4. Confirm the run deleted in Phase 3 Check 4 appears in the table.
-- [ ] Page loads, correct columns present, deleted run visible
+- [x] Page loads, correct columns present, deleted run visible
 
 **Check 3 — Snapshot data is accurate**
 1. On the Deleted Runs page, find the row for the run deleted in Phase 3.
@@ -402,23 +402,25 @@ Add a new per-project route and template that displays `TB_DELETION_LOG` rows in
    - **Deleted By** = `admin@local`
    - **Deleted At** = a recent timestamp (today's date)
    - **Description**, **Test Total/Pass/Fail**, **Time**, **Suite Total/Pass/Fail** match the values that were visible on the ehistoric page before deletion
-- [ ] Snapshot data matches what was in TB_EXECUTION before deletion
+- [x] Snapshot data matches what was in TB_EXECUTION before deletion
 
 **Check 4 — Delete a second run and confirm newest-first ordering**
 1. Log out, log in as `admin@local` / `admin`.
 2. Delete another run from ehistoric (different EID from Phase 3).
 3. Navigate to [http://localhost:5001/rf_full_data/deleted](http://localhost:5001/rf_full_data/deleted).
 4. Confirm the most recently deleted run appears at the **top** of the table.
-- [ ] Deleted runs ordered newest-first
+- [x] Deleted runs ordered newest-first
 
 **Check 5 — Regression: other pages unaffected**
 1. Navigate to [http://localhost:5001/rf_full_data/dashboard](http://localhost:5001/rf_full_data/dashboard) — confirm it loads.
 2. Navigate to [http://localhost:5001/rf_full_data/metrics](http://localhost:5001/rf_full_data/metrics) — confirm it loads.
 3. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric) — confirm remaining runs still display.
 4. Log out and log back in — confirm login/logout still works.
-- [ ] Dashboard, metrics, ehistoric, login/logout all unaffected
+- [x] Dashboard, metrics, ehistoric, login/logout all unaffected
 
-**All phases complete. Ready for PR.**
+**Phase 4 confirmed. ✅ All phases complete. Ready for PR.**
+
+*Note: During Phase 4 verification it was discovered that the Deleted Runs nav tab was missing from Dashboard, Flaky, Search, Tmetrics, and Compare templates (only ehistoric.html had been updated). All five templates were corrected as part of Phase 4. Additionally, project deletion routes and the index.html Delete button were gated to Lead role to close a regression introduced by the new Viewer role.*
 
 ---
 

--- a/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
@@ -125,11 +125,42 @@ Establish the database foundations: add `role` to `TB_USERS`, add `TB_DELETION_L
 - [ ] After migration: `SHOW TABLES IN <project_db> LIKE 'TB_DELETION_LOG'` returns one row per existing project
 
 #### Manual Verification
-- [ ] `docker-compose up` with fresh `init.sql` creates `TB_USERS` with `role` column and seed user with `role = 'lead'`
-- [ ] Migration script run against pre-existing container adds `role` column and `TB_DELETION_LOG` to all projects without dropping existing data
-- [ ] Running migration script a second time produces no errors and reports "already up-to-date"
 
-**Pause for human confirmation before proceeding to Phase 2.**
+**Check 1 — Fresh `init.sql` creates correct schema**
+1. Wipe all volumes and restart: `wsl -d Ubuntu -- bash -c "docker -H unix:///mnt/wsl/shared-docker/docker.sock compose -f /mnt/c/Git/robotframework-historic/docker-compose.yml down -v && docker -H unix:///mnt/wsl/shared-docker/docker.sock compose -f /mnt/c/Git/robotframework-historic/docker-compose.yml up -d"`
+2. Wait ~10 seconds for MySQL init to finish.
+3. Open phpMyAdmin at [http://localhost:8081](http://localhost:8081) — login as `root` / `password`.
+4. Navigate: **accounts** → **TB_USERS** → **Structure** tab.
+   - Confirm `role` column exists with type `varchar(20)`, Not Null, Default `viewer`.
+5. Navigate: **accounts** → **TB_USERS** → **Browse** tab.
+   - Confirm the `Admin` row shows `role = lead`.
+6. Navigate: **rf_full_data** → confirm `TB_DELETION_LOG` table exists in the left sidebar.
+- [x] `role` column visible in TB_USERS structure with DEFAULT 'viewer'
+- [x] Admin row has `role = lead`
+- [x] `TB_DELETION_LOG` table exists in rf_full_data
+
+**Check 2 — Migration against pre-existing container preserves data**
+*(This was run during automated verification. Confirm data was not dropped.)*
+1. Run: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT COUNT(*) FROM rf_full_data.TB_EXECUTION;"`
+   - Expected: `3` (original seed rows unchanged)
+2. Run: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT COUNT(*) FROM accounts.TB_USERS;"`
+   - Expected: `1` (Admin row still present, not duplicated)
+- [x] TB_EXECUTION row count unchanged after migration
+- [x] TB_USERS row count unchanged after migration
+
+**Check 3 — Migration script is idempotent**
+1. Re-copy and re-run the migration script:
+   ```
+   wsl -d Ubuntu -- bash -c "docker -H unix:///mnt/wsl/shared-docker/docker.sock cp /mnt/c/Git/robotframework-historic/scripts/migrate_qe7360.py robotframework-historic-rfhistoric-1:/tmp/migrate_qe7360.py && docker -H unix:///mnt/wsl/shared-docker/docker.sock exec robotframework-historic-rfhistoric-1 python /tmp/migrate_qe7360.py --host db --port 3306 --user root --password password"
+   ```
+2. Confirm output shows:
+   - `[SKIP] role column already exists`
+   - `[SKIP] admin@local already has a non-viewer role`
+   - `[OK] TB_DELETION_LOG ready` for each project (CREATE IF NOT EXISTS is a no-op)
+   - `Migration complete.` with no errors or tracebacks
+- [x] All steps SKIP or report already-up-to-date, no errors
+
+**Phase 1 confirmed. ✅ Proceeding to Phase 2.**
 
 ---
 
@@ -164,10 +195,36 @@ Wire `role` into the session at login so all subsequent routes and templates can
 - [ ] New user registered via form is stored with correct role in `TB_USERS`: `SELECT role FROM accounts.TB_USERS WHERE email='<new_email>'`
 
 #### Manual Verification
-- [ ] Log in as `admin@local` — confirm `session['role']` is `'lead'` (can be verified via Flask debug or by observing role-gated UI in Phase 3)
-- [ ] Register a new user as Viewer — confirm they appear in `TB_USERS` with `role = 'viewer'`
-- [ ] Register a new user as Lead — confirm they appear in `TB_USERS` with `role = 'lead'`
-- [ ] Registration form is not accessible when logged out (existing behavior preserved)
+
+**Check 1 — Login populates role in session**
+*(Full UI confirmation of session['role'] requires Phase 3 delete button. Verify indirectly via DB query.)*
+1. Open [http://localhost:5001](http://localhost:5001) and log in as `admin@local` / `admin`.
+2. Confirm the app loads without errors after login.
+3. In a separate terminal, verify the DB role: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT name, email, role FROM accounts.TB_USERS WHERE email='admin@local';"`
+   - Expected: `role = lead`
+- [ ] Login succeeds, app loads, DB confirms admin@local has role='lead'
+
+**Check 2 — Register a new Viewer user**
+1. While logged in as `admin@local`, navigate to [http://localhost:5001/register](http://localhost:5001/register).
+2. Fill in: name = `Test Viewer`, email = `viewer@local`, password = `viewer123`.
+3. In the Role dropdown, select **Viewer** and submit.
+4. Verify in DB: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT name, email, role FROM accounts.TB_USERS WHERE email='viewer@local';"`
+   - Expected: `role = viewer`
+- [ ] viewer@local appears in TB_USERS with role='viewer'
+
+**Check 3 — Register a new Lead user**
+1. While still logged in, navigate to [http://localhost:5001/register](http://localhost:5001/register).
+2. Fill in: name = `Test Lead`, email = `lead@local`, password = `lead123`.
+3. In the Role dropdown, select **Lead** and submit.
+4. Verify in DB: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT name, email, role FROM accounts.TB_USERS WHERE email='lead@local';"`
+   - Expected: `role = lead`
+- [ ] lead@local appears in TB_USERS with role='lead'
+
+**Check 4 — Registration form hidden when logged out**
+1. Log out of the app (navigate to [http://localhost:5001/logout](http://localhost:5001/logout) or use the logout button).
+2. Navigate directly to [http://localhost:5001/register](http://localhost:5001/register).
+3. Confirm the registration form does not appear (page should be blank or show no form — existing behavior).
+- [ ] Registration form not visible when logged out
 
 **Pause for human confirmation before proceeding to Phase 3.**
 
@@ -230,11 +287,41 @@ Add server-side role enforcement to the test run deletion route and convert dele
 - [ ] After Lead deletes a run: `SELECT * FROM TB_DELETION_LOG WHERE execution_id=<eid>` returns one row with correct `deleted_by` and snapshot data
 
 #### Manual Verification
-- [ ] Log in as Viewer — delete link is absent from ehistoric page
-- [ ] Log in as Lead — delete link is present on ehistoric page
-- [ ] Attempt direct URL navigation to `/<db>/deleconf/<eid>` as Viewer — confirm 403
-- [ ] Lead completes a deletion — confirm the run disappears from ehistoric and a log row exists in `TB_DELETION_LOG`
-- [ ] Dashboard metrics update correctly after deletion (no regression in `TB_PROJECT` total count)
+
+**Check 1 — Viewer does not see delete link**
+1. Log in as `viewer@local` / `viewer123` (created in Phase 2).
+2. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric).
+3. Confirm no **Delete** link appears in any row of the execution history table.
+- [ ] Delete link absent from all rows when logged in as Viewer
+
+**Check 2 — Lead sees delete link**
+1. Log out, then log in as `admin@local` / `admin`.
+2. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric).
+3. Confirm a **Delete** link appears on each execution row.
+- [ ] Delete link visible on rows when logged in as Lead
+
+**Check 3 — Viewer blocked from direct URL access**
+1. Log out, then log in as `viewer@local` / `viewer123`.
+2. Note an execution ID from the ehistoric page (e.g., `1`).
+3. Navigate directly to [http://localhost:5001/rf_full_data/deleconf/1](http://localhost:5001/rf_full_data/deleconf/1).
+4. Confirm a **403 Forbidden** response (not a redirect to login, not a deletion).
+- [ ] Direct URL to deleconf returns 403 for Viewer
+
+**Check 4 — Lead completes a deletion; audit log written**
+1. Log out, then log in as `admin@local` / `admin`.
+2. On [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric), note the total number of rows and the EID of the **last** row.
+3. Click **Delete** on that row → confirm on the deleconf page → submit.
+4. Confirm the run no longer appears in the ehistoric list (row count decreased by 1).
+5. Verify audit log: `docker exec robotframework-historic-db-1 mysql -uroot -ppassword -e "SELECT execution_id, deleted_by, deleted_at FROM rf_full_data.TB_DELETION_LOG;"`
+   - Expected: one row with `deleted_by = admin@local` and a recent `deleted_at` timestamp.
+- [ ] Deleted run disappears from ehistoric list
+- [ ] TB_DELETION_LOG contains one row with correct deleted_by and timestamp
+
+**Check 5 — Dashboard metrics still correct after deletion**
+1. Navigate to [http://localhost:5001/rf_full_data/dashboard](http://localhost:5001/rf_full_data/dashboard).
+2. Confirm the page loads without errors.
+3. Confirm the execution count reflects the deletion (one fewer run than before).
+- [ ] Dashboard loads without errors and shows updated counts
 
 **Pause for human confirmation before proceeding to Phase 4.**
 
@@ -295,11 +382,41 @@ Add a new per-project route and template that displays `TB_DELETION_LOG` rows in
 - [ ] Empty project returns page with "No deleted runs" (or equivalent empty state)
 
 #### Manual Verification
-- [ ] Log in as Viewer — "Deleted Runs" navigation link is visible on ehistoric page
-- [ ] Click "Deleted Runs" — page renders correctly with all expected columns
-- [ ] Delete a run as Lead — navigate to Deleted Runs tab — confirm run appears with correct `Deleted By` (email), `Deleted At` timestamp, and snapshot data
-- [ ] Deleted runs are ordered newest-first
-- [ ] Existing ehistoric, dashboard, and metrics pages unaffected
+
+**Check 1 — Deleted Runs link visible to Viewer**
+1. Log in as `viewer@local` / `viewer123`.
+2. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric).
+3. Confirm a **Deleted Runs** navigation link is visible (all users, not just Leads).
+- [ ] Deleted Runs link visible when logged in as Viewer
+
+**Check 2 — Deleted Runs page renders with correct columns**
+1. Click the **Deleted Runs** link (or navigate to [http://localhost:5001/rf_full_data/deleted](http://localhost:5001/rf_full_data/deleted)).
+2. Confirm the page loads without errors.
+3. Confirm the table has these column headers in order: **EID**, **Deleted By**, **Deleted At**, **Date**, **Description**, **Test Total**, **Test Pass**, **Test Fail**, **Time (m)**, **Suite Total**, **Suite Pass**, **Suite Fail**.
+4. Confirm the run deleted in Phase 3 Check 4 appears in the table.
+- [ ] Page loads, correct columns present, deleted run visible
+
+**Check 3 — Snapshot data is accurate**
+1. On the Deleted Runs page, find the row for the run deleted in Phase 3.
+2. Confirm:
+   - **Deleted By** = `admin@local`
+   - **Deleted At** = a recent timestamp (today's date)
+   - **Description**, **Test Total/Pass/Fail**, **Time**, **Suite Total/Pass/Fail** match the values that were visible on the ehistoric page before deletion
+- [ ] Snapshot data matches what was in TB_EXECUTION before deletion
+
+**Check 4 — Delete a second run and confirm newest-first ordering**
+1. Log out, log in as `admin@local` / `admin`.
+2. Delete another run from ehistoric (different EID from Phase 3).
+3. Navigate to [http://localhost:5001/rf_full_data/deleted](http://localhost:5001/rf_full_data/deleted).
+4. Confirm the most recently deleted run appears at the **top** of the table.
+- [ ] Deleted runs ordered newest-first
+
+**Check 5 — Regression: other pages unaffected**
+1. Navigate to [http://localhost:5001/rf_full_data/dashboard](http://localhost:5001/rf_full_data/dashboard) — confirm it loads.
+2. Navigate to [http://localhost:5001/rf_full_data/metrics](http://localhost:5001/rf_full_data/metrics) — confirm it loads.
+3. Navigate to [http://localhost:5001/rf_full_data/ehistoric](http://localhost:5001/rf_full_data/ehistoric) — confirm remaining runs still display.
+4. Log out and log back in — confirm login/logout still works.
+- [ ] Dashboard, metrics, ehistoric, login/logout all unaffected
 
 **All phases complete. Ready for PR.**
 

--- a/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/plans/active/2026-05-12-role-based-deletion-permissions.md
@@ -1,0 +1,345 @@
+---
+date: 2026-05-12
+author: Neil Howell
+domain: access-control
+jira: QE-7360
+research: >
+  .context/domains/access-control/research/current/2026-05-12-role-based-deletion-permissions.md
+  .context/domains/access-control/research/current/2026-05-12-deletion-log-schema-strategy.md
+status: active
+phases: 4
+---
+
+# QE-7360: Role-Based Permissions for Test Run Deletion — Implementation Plan
+
+## Overview
+Add a global Lead role to RFHistoric that gates test run deletion. Non-Lead users can view all test runs but cannot delete them. All users can view a new per-project "Deleted Runs" tab showing soft-deleted runs with audit metadata. Deletion is tracked in a new `TB_DELETION_LOG` table per project database, keeping the core `TB_EXECUTION` table unchanged.
+
+---
+
+## Current State Analysis
+
+*(Full details in research artifacts. Key facts for planning:)*
+
+- **Auth:** Flask session-based; `session['name']` and `session['email']` set at login (`app.py:47-48`). No role field exists anywhere.
+- **Deletion routes:** `GET /<db>/edelete/<eid>` (`app.py:259`) and `GET /<db>/delete` (`app.py:29`). Neither checks session state server-side — auth is template-only.
+- **Schema:** `accounts.TB_USERS` has no `role` column. Per-project `TB_EXECUTION` has no soft-delete or audit columns.
+- **Per-project DB creation:** Inline CREATE TABLE statements in `POST /<db>/newdb` route handler (`app.py`). No migration framework.
+- **Template pattern:** Standalone HTML files using `{% if session['name'] %}` for conditional rendering. No base template.
+- **Ticket scope:** Test run deletion only — project deletion (`/<db>/delete`) is explicitly out of scope.
+
+---
+
+## Desired End State
+
+- A `role` column exists on `accounts.TB_USERS` with values `'lead'` or `'viewer'` (default `'viewer'`)
+- `session['role']` is populated at login and available in all templates
+- `GET /<db>/edelete/<eid>` returns HTTP 403 if `session.get('role') != 'lead'`
+- The delete link on `ehistoric.html` is only rendered for Lead users
+- Deletion writes a snapshot row to `TB_DELETION_LOG` before hard-deleting from `TB_EXECUTION`
+- A new `GET /<db>/deleted` route renders all `TB_DELETION_LOG` rows for the project, newest first
+- New project databases include `TB_DELETION_LOG` table by default
+- Existing project databases receive `TB_DELETION_LOG` via one-time migration script
+- All existing non-deletion functionality is unaffected
+
+---
+
+## What We're NOT Doing
+
+- **Not** adding role protection to project/database deletion (`/<db>/delete`) — ticket explicitly scopes to test run deletion only
+- **Not** implementing Flask-Login or a `@login_required` decorator — inline session checks consistent with existing codebase pattern
+- **Not** adding soft-delete columns to `TB_EXECUTION` — `TB_DELETION_LOG` approach chosen (see schema strategy research)
+- **Not** modifying dashboard statistics — deleted runs excluded from aggregates automatically (hard-delete preserved)
+- **Not** adding role-based project visibility — all users see all projects
+- **Not** implementing restoration of deleted runs in this ticket
+
+---
+
+## Implementation Approach
+
+Four sequential phases, each independently deployable and verifiable:
+
+1. **Schema & Migration** — establish data foundations before any app logic changes
+2. **Role Integration in Auth Flow** — wire role into session so subsequent phases can use it
+3. **Delete Route Access Control + Audit Log** — the core access control change + deletion snapshot write
+4. **Deleted Runs Tab** — new route and template for the audit visibility requirement
+
+Each phase has its own success criteria. No phase depends on anything not completed in a prior phase.
+
+---
+
+## Phase 1: Schema Changes & Migration Script
+*Jira Subtask: QE-7360 — Phase 1*
+
+### Overview
+Establish the database foundations: add `role` to `TB_USERS`, add `TB_DELETION_LOG` DDL to new-project creation, and write a one-time migration script for existing installations.
+
+### Changes Required
+
+#### 1. `docker/init.sql`
+- Add `role VARCHAR(20) NOT NULL DEFAULT 'viewer'` column to `accounts.TB_USERS` table definition
+- Update the seed user row to include `role = 'lead'` (the default admin account should be a Lead)
+
+#### 2. `robotframework_historic/app.py` — `/newdb` route
+- Add `CREATE TABLE TB_DELETION_LOG` statement to the new-project database creation block alongside the existing `TB_EXECUTION`, `TB_SUITE`, `TB_TEST` creates
+- DDL:
+  ```sql
+  CREATE TABLE TB_DELETION_LOG (
+      log_id                   INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      execution_id             INT NOT NULL,
+      deleted_at               DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      deleted_by               VARCHAR(255),
+      snapshot_execution_date  DATETIME,
+      snapshot_execution_desc  TEXT,
+      snapshot_execution_pass  INT,
+      snapshot_execution_fail  INT,
+      snapshot_execution_total INT,
+      snapshot_execution_time  FLOAT,
+      snapshot_execution_stotal INT,
+      snapshot_execution_spass  INT,
+      snapshot_execution_sfail  INT,
+      INDEX (execution_id),
+      INDEX (deleted_at)
+  );
+  ```
+
+#### 3. `scripts/migrate_qe7360.py` (new file)
+- Standalone Python script using same MySQL connection parameters as `args.py`
+- Steps:
+  1. Connect to MySQL using host/port/user/password from CLI args (mirror `args.py` pattern)
+  2. Add `role` column to `accounts.TB_USERS` if it does not already exist (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS`)
+  3. Set `role = 'lead'` for the seed admin user (`admin@local`) if role is still `'viewer'`
+  4. Query all project names from `robothistoric.TB_PROJECT`
+  5. For each project database: `CREATE TABLE IF NOT EXISTS TB_DELETION_LOG (...)` using same DDL as above
+  6. Print a summary: projects migrated, projects already up-to-date, any errors
+- Script must be idempotent — safe to run multiple times
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `docker/init.sql` contains `role` column in `TB_USERS` definition: `grep -i "role" docker/init.sql`
+- [ ] `docker/init.sql` contains `TB_DELETION_LOG` CREATE statement: `grep "TB_DELETION_LOG" docker/init.sql`
+- [ ] Migration script exists: `Test-Path scripts/migrate_qe7360.py`
+- [ ] Migration script runs without error against a local instance: `python scripts/migrate_qe7360.py --host localhost --port 3306 --user root --password <pw>`
+- [ ] After migration: `SHOW COLUMNS FROM accounts.TB_USERS LIKE 'role'` returns one row
+- [ ] After migration: `SHOW TABLES IN <project_db> LIKE 'TB_DELETION_LOG'` returns one row per existing project
+
+#### Manual Verification
+- [ ] `docker-compose up` with fresh `init.sql` creates `TB_USERS` with `role` column and seed user with `role = 'lead'`
+- [ ] Migration script run against pre-existing container adds `role` column and `TB_DELETION_LOG` to all projects without dropping existing data
+- [ ] Running migration script a second time produces no errors and reports "already up-to-date"
+
+**Pause for human confirmation before proceeding to Phase 2.**
+
+---
+
+## Phase 2: Role Integration in Auth Flow
+*Jira Subtask: QE-7360 — Phase 2*
+
+### Overview
+Wire `role` into the session at login so all subsequent routes and templates can check `session['role']`. Update registration to support role assignment by Lead users.
+
+### Changes Required
+
+#### 1. `robotframework_historic/app.py` — login route (`app.py:37-66`)
+- After successful password verification and before redirect, query `role` from `TB_USERS`:
+  ```python
+  session['role'] = user['role']  # 'lead' or 'viewer'
+  ```
+- Add alongside existing `session['name']` and `session['email']` assignments (`app.py:47-48`)
+
+#### 2. `robotframework_historic/app.py` — register route (`app.py:69-85`)
+- Add `role` field to the form data read (default `'viewer'` if not submitted)
+- Include `role` in the `INSERT INTO TB_USERS` statement
+
+#### 3. `robotframework_historic/templates/register.html`
+- Add a `<select name="role">` field with options `viewer` (default, selected) and `lead`
+- Wrap in the existing `{% if session['name'] %}` block (registration already gated to logged-in users)
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Login with seed admin account sets `session['role'] = 'lead'` — verify by checking that the Lead-only delete button appears on `ehistoric.html` after login (manual step, but triggered by code change)
+- [ ] Login with a Viewer account sets `session['role'] = 'viewer'`
+- [ ] New user registered via form is stored with correct role in `TB_USERS`: `SELECT role FROM accounts.TB_USERS WHERE email='<new_email>'`
+
+#### Manual Verification
+- [ ] Log in as `admin@local` — confirm `session['role']` is `'lead'` (can be verified via Flask debug or by observing role-gated UI in Phase 3)
+- [ ] Register a new user as Viewer — confirm they appear in `TB_USERS` with `role = 'viewer'`
+- [ ] Register a new user as Lead — confirm they appear in `TB_USERS` with `role = 'lead'`
+- [ ] Registration form is not accessible when logged out (existing behavior preserved)
+
+**Pause for human confirmation before proceeding to Phase 3.**
+
+---
+
+## Phase 3: Delete Route Access Control + Audit Log Write
+*Jira Subtask: QE-7360 — Phase 3*
+
+### Overview
+Add server-side role enforcement to the test run deletion route and convert deletion from a pure hard-delete into an audit-log write followed by a hard-delete. Update the ehistoric template to only show the delete link for Lead users.
+
+### Changes Required
+
+#### 1. `robotframework_historic/app.py` — `delete_eid_conf` route (`app.py:255-258`)
+- At the top of the handler, add session role check:
+  ```python
+  if session.get('role') != 'lead':
+      return 'Forbidden', 403
+  ```
+
+#### 2. `robotframework_historic/app.py` — `delete_eid` route (`app.py:259-274`)
+- At the top of the handler, add session role check:
+  ```python
+  if session.get('role') != 'lead':
+      return 'Forbidden', 403
+  ```
+- Before the three DELETE statements, INSERT a snapshot row into `TB_DELETION_LOG`:
+  ```python
+  cursor.execute(
+      "INSERT INTO TB_DELETION_LOG "
+      "(execution_id, deleted_by, snapshot_execution_date, snapshot_execution_desc, "
+      "snapshot_execution_pass, snapshot_execution_fail, snapshot_execution_total, "
+      "snapshot_execution_time, snapshot_execution_stotal, snapshot_execution_spass, snapshot_execution_sfail) "
+      "SELECT Execution_Id, %s, Execution_Date, Execution_Desc, "
+      "Execution_Pass, Execution_Fail, Execution_Total, "
+      "Execution_Time, Execution_STotal, Execution_SPass, Execution_SFail "
+      "FROM TB_EXECUTION WHERE Execution_Id=%s",
+      (session.get('email'), eid)
+  )
+  ```
+- The existing three DELETE statements remain unchanged after this INSERT
+
+#### 3. `robotframework_historic/templates/ehistoric.html` — delete link (`ehistoric.html:75`)
+- Wrap the existing delete link in a role check:
+  ```html
+  {% if session.get('role') == 'lead' %}
+  <a href="./deleconf/{{item[0]}}">Delete</a>
+  {% endif %}
+  ```
+
+#### 4. `robotframework_historic/templates/deleconf.html`
+- Add a check at the top of the confirmation page body: if `session.get('role') != 'lead'`, display an "Insufficient permissions" message instead of the confirmation form. (Belt-and-suspenders; the route handler is the true enforcement point.)
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] Unauthenticated GET to `/<db>/edelete/<eid>` returns HTTP 403 (no session at all)
+- [ ] Authenticated Viewer GET to `/<db>/edelete/<eid>` returns HTTP 403
+- [ ] Authenticated Lead GET to `/<db>/edelete/<eid>` returns redirect (HTTP 302) — deletion proceeds
+- [ ] After Lead deletes a run: `SELECT * FROM TB_DELETION_LOG WHERE execution_id=<eid>` returns one row with correct `deleted_by` and snapshot data
+
+#### Manual Verification
+- [ ] Log in as Viewer — delete link is absent from ehistoric page
+- [ ] Log in as Lead — delete link is present on ehistoric page
+- [ ] Attempt direct URL navigation to `/<db>/deleconf/<eid>` as Viewer — confirm 403
+- [ ] Lead completes a deletion — confirm the run disappears from ehistoric and a log row exists in `TB_DELETION_LOG`
+- [ ] Dashboard metrics update correctly after deletion (no regression in `TB_PROJECT` total count)
+
+**Pause for human confirmation before proceeding to Phase 4.**
+
+---
+
+## Phase 4: Deleted Runs Tab
+*Jira Subtask: QE-7360 — Phase 4*
+
+### Overview
+Add a new per-project route and template that displays `TB_DELETION_LOG` rows in descending order, visible to all authenticated users. Add navigation to the tab from the execution history page.
+
+### Changes Required
+
+#### 1. `robotframework_historic/app.py` — new route
+- Add `GET /<db>/deleted` route handler:
+  ```python
+  @app.route('/<db>/deleted')
+  def deleted_runs(db):
+      # Connect to project database
+      # SELECT * FROM TB_DELETION_LOG ORDER BY deleted_at DESC
+      # Render deletedhistoric.html with results
+  ```
+- No role check — all users (authenticated or not) can view deleted runs per ticket requirements
+
+#### 2. `robotframework_historic/templates/deletedhistoric.html` (new file)
+- Model structure after `ehistoric.html` (same nav, same project header)
+- Table columns in this order (per decision in schema strategy research):
+  | Column Header | Data Source |
+  |---|---|
+  | EID | `item['execution_id']` |
+  | Deleted By | `item['deleted_by']` |
+  | Deleted At | `item['deleted_at']` |
+  | Date | `item['snapshot_execution_date']` |
+  | Description | `item['snapshot_execution_desc']` |
+  | Test Total | `item['snapshot_execution_total']` |
+  | Test Pass | `item['snapshot_execution_pass']` |
+  | Test Fail | `item['snapshot_execution_fail']` |
+  | Time (m) | `item['snapshot_execution_time']` |
+  | Suite Total | `item['snapshot_execution_stotal']` |
+  | Suite Pass | `item['snapshot_execution_spass']` |
+  | Suite Fail | `item['snapshot_execution_sfail']` |
+- Display "No deleted runs" message when `TB_DELETION_LOG` is empty
+- No delete controls on this page
+
+#### 3. `robotframework_historic/templates/ehistoric.html` — navigation
+- Add a navigation link to the Deleted Runs tab, visible to all users:
+  ```html
+  <a href="./deleted">Deleted Runs</a>
+  ```
+- Position consistent with existing navigation links in the template
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `GET /<db>/deleted` returns HTTP 200 for an authenticated user
+- [ ] `GET /<db>/deleted` returns HTTP 200 for an unauthenticated user (public read)
+- [ ] After a Lead deletes a run, `GET /<db>/deleted` response body contains the deleted EID
+- [ ] Empty project returns page with "No deleted runs" (or equivalent empty state)
+
+#### Manual Verification
+- [ ] Log in as Viewer — "Deleted Runs" navigation link is visible on ehistoric page
+- [ ] Click "Deleted Runs" — page renders correctly with all expected columns
+- [ ] Delete a run as Lead — navigate to Deleted Runs tab — confirm run appears with correct `Deleted By` (email), `Deleted At` timestamp, and snapshot data
+- [ ] Deleted runs are ordered newest-first
+- [ ] Existing ehistoric, dashboard, and metrics pages unaffected
+
+**All phases complete. Ready for PR.**
+
+---
+
+## Testing Strategy
+
+### Per-Phase Verification
+Each phase has explicit automated and manual success criteria defined above. No phase proceeds until its criteria are met and human-confirmed.
+
+### Regression Checks (after Phase 4)
+- [ ] Login / logout flow unchanged
+- [ ] New user registration works end-to-end
+- [ ] New project creation succeeds and includes `TB_DELETION_LOG`
+- [ ] Dashboard metrics (pass %, total count) correct after test run deletion
+- [ ] Ehistoric page loads correctly with LIMIT 500
+
+### Edge Cases
+- Project database with zero executions — Deleted Runs tab shows empty state
+- Lead user session expires mid-deletion — 403 returned cleanly
+- Migration script run against a project DB that already has `TB_DELETION_LOG` — no error, reports already-up-to-date
+- Viewer attempts direct URL deletion — 403 returned (not a redirect to login)
+
+---
+
+## Migration Notes
+
+**One-time migration script** (`scripts/migrate_qe7360.py`) must be run **before** deploying the updated application code. Running order:
+
+1. Run `scripts/migrate_qe7360.py` against the target MySQL instance
+2. Set existing Lead users' `role` to `'lead'` manually (or update the migration script with known email addresses)
+3. Deploy updated application code
+4. Verify with smoke test: login, confirm role in session, attempt deletion as Lead and Viewer
+
+The seed `admin@local` account is automatically set to `role = 'lead'` by the migration script.
+
+---
+
+## References
+
+- Research (foundations): `.context/domains/access-control/research/current/2026-05-12-role-based-deletion-permissions.md`
+- Research (schema strategy): `.context/domains/access-control/research/current/2026-05-12-deletion-log-schema-strategy.md`
+- Jira ticket: [QE-7360](https://accruent.atlassian.net/browse/QE-7360)

--- a/.context/domains/access-control/research/current/2026-05-12-deletion-log-schema-strategy.md
+++ b/.context/domains/access-control/research/current/2026-05-12-deletion-log-schema-strategy.md
@@ -5,7 +5,7 @@ domain: access-control
 jira: QE-7360
 parent-research: 2026-05-12-role-based-deletion-permissions.md
 scope: "app.py SQL queries, docker/init.sql TB_EXECUTION DDL, templates/ehistoric.html"
-status: draft
+status: validated
 ---
 
 # Research: TB_DELETION_LOG vs TB_EXECUTION Columns — Schema Strategy
@@ -213,10 +213,18 @@ DELETE FROM TB_EXECUTION WHERE Execution_Id=%s;
 
 ---
 
-### Remaining Open Questions
+### Decisions (Open Questions Resolved)
 
-1. **Dashboard statistics scope:** Should all-time pass/fail aggregates (lines 151, 157–163) include or exclude deleted runs? Option A requires a decision; Option B excludes them automatically.
+1. **Dashboard statistics scope:** Deleted runs are **excluded** from all-time dashboard aggregates. Option B (TB_DELETION_LOG) achieves this automatically — hard-deleted rows disappear from all existing queries with zero changes.
 
-2. **TB_SUITE / TB_TEST fate on deletion:** Under either option, should suite and test detail rows be hard-deleted when a run is deleted, or also archived/logged?
+2. **TB_SUITE / TB_TEST fate on deletion:** **Hard-delete both**, same as current behavior. The deleted-runs tab is a list view only (no drill-down), so suite/test detail rows serve no purpose once a run is deleted. Preserving them as orphans or in archive tables adds complexity for data that is never displayed.
 
-3. **Deleted-runs tab display columns:** Exact column set for the new deleted-runs view — determines which columns to snapshot in Option B log.
+3. **Deleted-runs tab display columns:** All columns from the ehistoric page, plus `Deleted By` and `Deleted At` as the leading identifier columns (positioned after EID to distinguish this view from ehistoric). Full column order:
+   - EID (`execution_id`)
+   - Deleted By (`deleted_by`)
+   - Deleted At (`deleted_at`)
+   - Date (`snapshot_execution_date`)
+   - Description (`snapshot_execution_desc`)
+   - Test Total / Pass / Fail (`snapshot_execution_total/pass/fail`)
+   - Time (m) (`snapshot_execution_time`)
+   - Suite Total / Pass / Fail (`snapshot_execution_stotal/spass/sfail`)

--- a/.context/domains/access-control/research/current/2026-05-12-deletion-log-schema-strategy.md
+++ b/.context/domains/access-control/research/current/2026-05-12-deletion-log-schema-strategy.md
@@ -1,0 +1,222 @@
+---
+date: 2026-05-12
+author: Neil Howell
+domain: access-control
+jira: QE-7360
+parent-research: 2026-05-12-role-based-deletion-permissions.md
+scope: "app.py SQL queries, docker/init.sql TB_EXECUTION DDL, templates/ehistoric.html"
+status: draft
+---
+
+# Research: TB_DELETION_LOG vs TB_EXECUTION Columns — Schema Strategy
+## Jira: QE-7360 (Follow-up to role-based-deletion-permissions research)
+
+### Research Question
+What codebase facts are relevant to choosing between Option A (nullable columns on TB_EXECUTION) and Option B (separate TB_DELETION_LOG table) for tracking soft-deleted test runs?
+
+### Summary
+The codebase contains 14 SELECT queries against TB_EXECUTION across 7 routes, all using either SELECT * or named column subsets with no existing WHERE clause filtering on row attributes — only by Execution_Id. Four of these are full-table-scan aggregates (dashboard statistics). The ehistoric template uses hard-coded positional indexing (item[0]…item[9]), meaning any column insertion into TB_EXECUTION breaks display. No JOINs exist between TB_EXECUTION and other tables. The per-project DDL lives inline in the `/newdb` route handler.
+
+---
+
+### Findings
+
+#### TB_EXECUTION Query Patterns
+
+| Line | Route | Query | Type | WHERE on data? |
+|------|-------|-------|------|---------------|
+| 136 | `/<db>/dashboard` | `SELECT COUNT(Execution_Id) from TB_EXECUTION` | Aggregate | No |
+| 145 | `/<db>/dashboard` | `SELECT Execution_Pass, Execution_Fail, Execution_Total, Execution_Time ... LIMIT 1` | Named cols | No |
+| 148 | `/<db>/dashboard` | `SELECT SUM(...), COUNT(...) from (... LIMIT 10) AS T` | Aggregate subquery | No |
+| 151 | `/<db>/dashboard` | `SELECT SUM(...), COUNT(Execution_Id) from TB_EXECUTION` | **Full table scan aggregate** | No |
+| 154 | `/<db>/dashboard` | `SELECT Execution_Id, Execution_Pass, Execution_Fail, Execution_Time ... LIMIT 10` | Named cols | No |
+| 157 | `/<db>/dashboard` | `select execution_pass, ROUND(MIN(...)), ROUND(AVG(...)), ROUND(MAX(...)) ...` | **Full table scan aggregate** | No |
+| 160 | `/<db>/dashboard` | `select execution_fail, ROUND(MIN(...)), ROUND(AVG(...)), ROUND(MAX(...)) ...` | **Full table scan aggregate** | No |
+| 163 | `/<db>/dashboard` | `select execution_time, ROUND(MIN(...)), ROUND(AVG(...)), ROUND(MAX(...)) ...` | **Full table scan aggregate** | No |
+| 185 | `/<db>/ehistoric` | `SELECT * from TB_EXECUTION order by Execution_Id desc LIMIT 500` | SELECT * | No |
+| 203 | `/<db>/edelete/<eid>` | `SELECT Execution_Pass, Execution_Total ... ORDER BY Execution_Id DESC LIMIT 1` | Named cols | No |
+| 206 | `/<db>/edelete/<eid>` | `SELECT COUNT(*) from TB_EXECUTION` | Aggregate | No |
+| 234 | `/<db>/tmetrics` | `SELECT Execution_Id from TB_EXECUTION order by Execution_Id desc LIMIT 1` | Single col | No |
+| 255 | `/<db>/metrics/<eid>` | `SELECT * from TB_EXECUTION WHERE Execution_Id=%s` | SELECT * | Yes — by Execution_Id only |
+| 305 | `/<db>/flaky` | Subquery selecting Execution_Id with LIMIT 5 window | Single col | No |
+| 307 | `/<db>/flaky` | `SELECT COUNT(Execution_Id) from TB_EXECUTION` | Aggregate | No |
+
+**Key observations:**
+- 4 full-table-scan aggregate queries (lines 151, 157, 160, 163) — dashboard statistics covering all-time data
+- 2 SELECT * queries (lines 185, 255) — both would silently include new columns
+- WHERE filtering by row attribute is absent in all queries except by Execution_Id exact match
+- **14 query sites would require `WHERE is_deleted = 0` added** if Option A is chosen
+
+#### Per-Project Database Creation
+
+- **Route:** `POST /<db>/newdb` (`app.py` — inline CREATE TABLE statements in handler)
+- **Schema method:** Inline DDL in Python route; no stored procedures, migration files, or templates
+- **TB_EXECUTION DDL (exact, from newdb handler):**
+  ```sql
+  CREATE TABLE TB_EXECUTION (
+      Execution_Id    INT NOT NULL auto_increment primary key,
+      Execution_Date  DATETIME,
+      Execution_Desc  TEXT,
+      Execution_Total INT,
+      Execution_Pass  INT,
+      Execution_Fail  INT,
+      Execution_Time  FLOAT,
+      Execution_STotal INT,
+      Execution_SPass  INT,
+      Execution_SFail INT,
+      Execution_Skip  INT,
+      Execution_SSkip INT
+  );
+  ```
+- **12 columns total.** PRIMARY KEY on `Execution_Id` only — no other indexes.
+- Both new project databases AND the one-time migration script must be updated for either option.
+
+#### Multi-Table JOIN Patterns
+
+**No JOINs exist** between TB_EXECUTION and any other table. The cascade delete at `app.py:260-261` uses three separate DELETE statements, not a JOIN. Dashboard, ehistoric, tmetrics, and flaky routes all query TB_EXECUTION in isolation.
+
+#### ehistoric Template Column Mapping
+
+Feed query: `SELECT * from TB_EXECUTION order by Execution_Id desc LIMIT 500` (`app.py:185`)
+
+Positional mapping in `templates/ehistoric.html`:
+
+| Index | Column | Displayed? |
+|-------|--------|-----------|
+| `item[0]` | `Execution_Id` | Yes — "EID" |
+| `item[1]` | `Execution_Date` | Yes — "Date" |
+| `item[2]` | `Execution_Desc` | Yes — "Description" |
+| `item[3]` | `Execution_Total` | Yes — "Test Total" |
+| `item[4]` | `Execution_Pass` | Yes — "Test Pass" |
+| `item[5]` | `Execution_Fail` | Yes — "Test Fail" |
+| `item[6]` | `Execution_Time` | Yes — "Time (m)" |
+| `item[7]` | `Execution_STotal` | Yes — "Suite Total" |
+| `item[8]` | `Execution_SPass` | Yes — "Suite Pass" |
+| `item[9]` | `Execution_SFail` | Yes — "Suite Fail" |
+| `item[10]` | `Execution_Skip` | Not displayed |
+| `item[11]` | `Execution_SSkip` | Not displayed |
+
+**Template impact:** Inserting columns anywhere in TB_EXECUTION shifts all `item[N]` indices and breaks the ehistoric display. Appending columns at the end (indices 12+) is safe for ehistoric, but the SELECT * at `app.py:255` (metrics route) would also pick them up without display issues.
+
+#### Snapshot Value Analysis
+
+Columns worth capturing in a deletion log for the deleted-runs tab:
+
+| Column | Type | Value if Snapshotted |
+|--------|------|---------------------|
+| `Execution_Date` | DATETIME | **High** — source timestamp; user-meaningful; non-derivable |
+| `Execution_Desc` | TEXT | **High** — user-provided text; only copy |
+| `Execution_Total` | INT | Medium — fixed at execution time; useful for summary display |
+| `Execution_Pass` | INT | Medium — historical pass rate; useful for deleted-runs tab |
+| `Execution_Fail` | INT | Medium — historical fail rate |
+| `Execution_Time` | FLOAT | Medium — runtime; useful for historical comparison |
+| `Execution_STotal` | INT | Low-Medium — suite counts not displayed in ehistoric by default |
+| `Execution_SPass` | INT | Low |
+| `Execution_SFail` | INT | Low |
+| `Execution_Skip` | INT | Low — not currently displayed anywhere |
+| `Execution_SSkip` | INT | Low — not currently displayed anywhere |
+
+---
+
+### Option A Facts (Columns on TB_EXECUTION)
+
+**New columns required:**
+```sql
+ALTER TABLE TB_EXECUTION
+  ADD COLUMN is_deleted TINYINT NOT NULL DEFAULT 0,
+  ADD COLUMN deleted_at DATETIME NULL,
+  ADD COLUMN deleted_by VARCHAR(255) NULL;
+```
+
+**Query change surface:** 14 SELECT query sites require `WHERE is_deleted = 0` added
+- 4 are full-table-scan aggregates — require index on `(is_deleted, Execution_Id)` for performance
+- 2 use SELECT * — silently include new columns, no template breakage if appended
+
+**Template changes:** None if columns appended at end (items[12], [13], [14]); ehistoric indices item[0]…item[11] unchanged
+
+**Hard-delete route change:** `DELETE FROM TB_EXECUTION WHERE Execution_Id='%s'` must become:
+```sql
+UPDATE TB_EXECUTION SET is_deleted=1, deleted_at=NOW(), deleted_by=%s WHERE Execution_Id=%s
+```
+
+**Cascade impact:** When a run is soft-deleted, TB_SUITE and TB_TEST rows remain; decision required on whether to also soft-delete or hard-delete them
+
+**Count accuracy impact:** Lines 136, 206 (COUNT queries used to update `TB_PROJECT.Total_Executions`) must filter `WHERE is_deleted = 0` to remain accurate
+
+**Migration scope per existing project DB:** 1 × `ALTER TABLE TB_EXECUTION ADD COLUMN ...`
+
+**Full code change surface:** 1 schema change + 14 query edits + 1 delete→update conversion + 2 count query corrections
+
+---
+
+### Option B Facts (Separate TB_DELETION_LOG)
+
+**New table DDL per project database:**
+```sql
+CREATE TABLE TB_DELETION_LOG (
+    log_id                   INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id             INT NOT NULL,
+    deleted_at               DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_by               VARCHAR(255),
+    snapshot_execution_date  DATETIME,
+    snapshot_execution_desc  TEXT,
+    snapshot_execution_pass  INT,
+    snapshot_execution_fail  INT,
+    snapshot_execution_total INT,
+    snapshot_execution_time  FLOAT,
+    INDEX (execution_id),
+    INDEX (deleted_at)
+);
+```
+
+**Existing query change surface:** 0 — no existing SELECT, aggregate, or dashboard queries touched
+
+**Write pattern at deletion (app.py:259):** INSERT into TB_DELETION_LOG before or after the existing DELETE:
+```sql
+INSERT INTO TB_DELETION_LOG (execution_id, deleted_by, snapshot_*)
+  SELECT Execution_Id, %s, Execution_Date, Execution_Desc, ...
+  FROM TB_EXECUTION WHERE Execution_Id=%s;
+DELETE FROM TB_EXECUTION WHERE Execution_Id=%s;
+```
+
+**Hard delete:** Unchanged semantics — rows still hard-deleted from TB_EXECUTION
+
+**CASCADE impact:** TB_SUITE and TB_TEST still hard-deleted; no orphan rows
+
+**Count accuracy:** `COUNT(*)` and `COUNT(Execution_Id)` queries remain accurate without modification
+
+**Template impact:** None — no changes to ehistoric.html, dashboard.html, or any existing template
+
+**New route required:** `GET /<db>/deleted` — new handler reading from TB_DELETION_LOG
+
+**New template required:** New `deletedhistoric.html` rendering TB_DELETION_LOG rows
+
+**Migration scope per existing project DB:** 1 × `CREATE TABLE TB_DELETION_LOG (...)`
+
+**Full code change surface:** 1 new table DDL + 1 INSERT added to delete handler + 1 new route + 1 new template
+
+---
+
+### Constraints Relevant to This Decision
+
+1. **Positional template indexing is the hardest constraint for Option A.** Columns must be appended at the end of TB_EXECUTION to avoid breaking item[0]…item[11] references. This is achievable but fragile — any future column insertion breaks it again.
+
+2. **Four full-table-scan aggregate queries (lines 151, 157, 160, 163)** must each gain a `WHERE is_deleted = 0` filter and a composite index under Option A, or they silently include deleted data in dashboard statistics.
+
+3. **LIMIT 500 on ehistoric** means under Option A, if 200 rows are soft-deleted within the top 500, the effective visible window shrinks to 300 without increasing the LIMIT.
+
+4. **No existing soft-delete pattern** — Option A introduces new conditional delete semantics that must be consistently applied; Option B keeps hard-delete semantics unchanged.
+
+5. **Per-project DDL inline in route handler** — both options require updating the `/newdb` handler AND a one-time migration script for existing databases.
+
+6. **TB_DELETION_LOG is write-once/append-only** — simpler concurrency model than Option A's UPDATE-then-read pattern.
+
+---
+
+### Remaining Open Questions
+
+1. **Dashboard statistics scope:** Should all-time pass/fail aggregates (lines 151, 157–163) include or exclude deleted runs? Option A requires a decision; Option B excludes them automatically.
+
+2. **TB_SUITE / TB_TEST fate on deletion:** Under either option, should suite and test detail rows be hard-deleted when a run is deleted, or also archived/logged?
+
+3. **Deleted-runs tab display columns:** Exact column set for the new deleted-runs view — determines which columns to snapshot in Option B log.

--- a/.context/domains/access-control/research/current/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/research/current/2026-05-12-role-based-deletion-permissions.md
@@ -1,0 +1,336 @@
+---
+date: 2026-05-12
+author: Neil Howell
+domain: access-control
+jira: QE-7360
+scope: "robotframework_historic/app.py, docker/init.sql, robotframework_historic/templates/"
+status: draft
+---
+
+# Research: Role-Based Access Control Foundations in RFHistoric
+## Jira: QE-7360 — Add Role-Based Permissions for Test Run Deletion
+
+### Research Question
+How is the existing authentication, user model, test run deletion, and database schema structured in RFHistoric, in preparation for adding role-based delete permissions and a deleted-runs visibility tab?
+
+### Summary
+RFHistoric uses Flask session-based authentication with a simple single-table user model (`accounts.TB_USERS`). Sessions are checked in templates, not via route decorators. The application has two deletion flows: test run execution deletion and entire project/database deletion. Both deletion routes currently lack any authentication checks — they are accessible via direct URL without verifying session state. The database schema has no role, permission, or soft-delete columns; deletion is immediate via SQL DELETE statements with no audit trail.
+
+---
+
+### Detailed Findings
+
+#### 1. User Model & Authentication
+
+**User Storage:**
+- Table: `accounts.TB_USERS` (`docker/init.sql:19`)
+- Columns: `id` (INT AUTO_INCREMENT PRIMARY KEY), `name` (VARCHAR 255), `email` (VARCHAR 255), `password` (VARCHAR 255)
+- Password storage: Bcrypt-hashed (example seed: `$2b$12$/3e9h/RIPYK2xIKOoIVXd.mpHrBT4AsWkv8wJYXTrQWJEu4Ah3v8u`)
+- Default test account: `admin@local` / `admin`
+
+**Session Management:**
+- Framework: Flask `session` object (`app.py:1`)
+- Session variables set at login (`app.py:47-48`):
+  - `session['name']` — user's display name
+  - `session['email']` — user's email
+- Session cleared on logout (`app.py:67`): `session.clear()`
+- Session secret key: Random 12-character alphanumeric salt generated at app startup (`app.py:632`)
+
+**Login Flow:**
+- Route: `@app.route('/login', methods=["GET","POST"])` (`app.py:37`)
+- Method: POST form submission (email + password)
+- Password verification via `bcrypt.hashpw()`
+- No existing role/permission field in TB_USERS — all users are treated equally post-login
+
+**Registration Flow:**
+- Route: `@app.route('/register', methods=["GET", "POST"])` (`app.py:69`)
+- Protection: Checks `{% if session['name'] %}` in template — only logged-in users can register new users (`templates/register.html:51`)
+- Password hashing: `bcrypt.hashpw(password, bcrypt.gensalt())`
+
+**Authentication Pattern:**
+- **No route decorator pattern** (e.g., `@login_required`) — Flask-Login is not used
+- Session checks occur **in templates only**, not in route handlers
+- Example: `index.html:64-66` shows logout/register buttons only if `session['name']` is truthy
+- Delete buttons rendered only if `{% if session['name'] %}` (`index.html:77`)
+- **Critical gap:** Route handlers do NOT verify session state before executing deletion logic
+
+---
+
+#### 2. Current Test Run Deletion Flow
+
+**Execution (Test Run) Deletion:**
+
+1. **Confirmation Page Route:**
+   - Path: `GET /<db>/deleconf/<eid>`
+   - Handler: `delete_eid_conf(db, eid)` at `app.py:255`
+   - Action: Renders `templates/deleconf.html`
+   - No session check in handler
+
+2. **Actual Deletion Route:**
+   - Path: `GET /<db>/edelete/<eid>`
+   - Handler: `delete_eid(db, eid)` at `app.py:259`
+   - HTTP method: GET (not POST or DELETE)
+   - SQL operations (`app.py:260-261`):
+     ```sql
+     DELETE FROM TB_EXECUTION WHERE Execution_Id='%s';
+     DELETE FROM TB_SUITE WHERE Execution_Id='%s';
+     DELETE FROM TB_TEST WHERE Execution_Id='%s';
+     ```
+   - Post-deletion: Recalculates and updates `robothistoric.TB_PROJECT` metrics (`app.py:273`)
+   - Redirects to: `ehistoric` view
+   - **No session check before deletion**
+
+**Project/Database Deletion:**
+
+1. **Confirmation Page Route:**
+   - Path: `GET /<db>/deldbconf`
+   - Handler: `delete_db_conf(db)` at `app.py:26`
+   - Action: Renders `templates/deldbconf.html`
+   - No session check
+
+2. **Actual Deletion Route:**
+   - Path: `GET /<db>/delete`
+   - Handler: `delete_db(db)` at `app.py:29`
+   - HTTP method: GET
+   - SQL operations (`app.py:30-31`):
+     ```sql
+     DROP DATABASE <db>;
+     DELETE FROM robothistoric.TB_PROJECT WHERE Project_Name='<db>';
+     ```
+   - Redirects to: `index`
+   - **No session check before deletion**
+
+**Deletion Characteristics:**
+- Hard delete — immediate, permanent
+- No soft-delete flag or archive state
+- No audit trail or `deleted_at` timestamp
+- No restoration capability
+
+---
+
+#### 3. Database Schema
+
+**Core Registry Database: `robothistoric`**
+
+Table: `TB_PROJECT` (`docker/init.sql`)
+| Column | Type | Notes |
+|--------|------|-------|
+| Project_Id | INT AUTO_INCREMENT PK | Unique identifier |
+| Project_Name | VARCHAR(255) | Database name for project |
+| Project_Desc | TEXT | Pipeline link or description |
+| Project_Image | TEXT | Logo/image URL |
+| Created_Date | DATETIME | Creation timestamp |
+| Last_Updated | DATETIME | Last metric update |
+| Total_Executions | INT | Count of test runs |
+| Recent_Pass_Perc | FLOAT | Most recent pass % |
+| Overall_Pass_Perc | FLOAT | Aggregate pass % |
+
+**User Accounts Database: `accounts`**
+
+Table: `TB_USERS`
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INT AUTO_INCREMENT PK | Unique user identifier |
+| name | VARCHAR(255) | Display name |
+| email | VARCHAR(255) | Login email (no unique constraint) |
+| password | VARCHAR(255) | Bcrypt-hashed password |
+
+**Per-Project Databases: `{project_name}`**
+
+Table: `TB_EXECUTION`
+| Column | Type | Notes |
+|--------|------|-------|
+| Execution_Id | INT AUTO_INCREMENT PK | Test run identifier |
+| Execution_Date | DATETIME | Timestamp of run |
+| Execution_Desc | TEXT | Run description |
+| Execution_Total | INT | Total test count |
+| Execution_Pass | INT | Passed test count |
+| Execution_Fail | INT | Failed test count |
+| Execution_Time | FLOAT | Total execution time |
+| Execution_STotal | INT | Total suite count |
+| Execution_SPass | INT | Passed suite count |
+| Execution_SFail | INT | Failed suite count |
+| Execution_Skip | INT | Skipped test count |
+| Execution_SSkip | INT | Skipped suite count |
+
+Table: `TB_SUITE`
+| Column | Type | Notes |
+|--------|------|-------|
+| Suite_Id | INT AUTO_INCREMENT PK | Suite identifier |
+| Execution_Id | INT | FK to TB_EXECUTION (implicit) |
+| Suite_Name | TEXT | Test suite name |
+| Suite_Status | CHAR(4) | PASS or FAIL |
+| Suite_Total/Pass/Fail/Skip | INT | Test counts |
+| Suite_Time | FLOAT | Suite execution time |
+
+Table: `TB_TEST`
+| Column | Type | Notes |
+|--------|------|-------|
+| Test_Id | INT AUTO_INCREMENT PK | Test identifier |
+| Execution_Id | INT | FK to TB_EXECUTION (implicit) |
+| Test_Name | TEXT | Test case name |
+| Test_Status | CHAR(4) | PASS or FAIL |
+| Test_Time | FLOAT | Execution time |
+| Test_Error | TEXT | Error message if failed |
+| Test_Comment | TEXT | User-added note |
+| Test_Assigned_To | TEXT | Assigned person (currently unused) |
+| Test_ETA | TEXT | Estimated fix time (currently unused) |
+| Test_Review_By | TEXT | Review assignment (currently unused) |
+| Test_Issue_Type | TEXT | Issue classification (currently unused) |
+| Test_Tag | TEXT | Test tag/category |
+| Test_Updated | TEXT | Last update timestamp |
+
+**Foreign Key Relationships:**
+- `TB_SUITE.Execution_Id` → `TB_EXECUTION.Execution_Id` (implicit only — no FK constraint defined)
+- `TB_TEST.Execution_Id` → `TB_EXECUTION.Execution_Id` (implicit only)
+- No explicit relationship between `TB_PROJECT` and test tables (linked implicitly via database name)
+
+**Missing Columns Relevant to This Ticket:**
+- No `role` or `permission` column in `TB_USERS`
+- No `owner_id` or `creator_id` in `TB_PROJECT`
+- No `deleted_at`, `is_deleted`, or `deleted_by` flag in `TB_EXECUTION`
+- No audit or deletion log table
+
+---
+
+#### 4. Template & UI Patterns
+
+**Session Variable Usage in Templates:**
+
+`templates/index.html` — Project list page
+- Lines 64-66: Conditionally show logout/register buttons on `session['name']`
+  ```html
+  {% if session['name'] %}
+    <a href="/logout">Logout</a>
+    <a href="/register">New User</a>
+  {% else %}
+    <a href="/login">Login</a>
+  {% endif %}
+  ```
+- Line 77: Delete button gated on `session['name']`
+  ```html
+  {% if session['name'] %}
+    <a href="{{item[1]}}/deldbconf" class="btn btn-danger">Delete</a>
+  {% endif %}
+  ```
+
+`templates/register.html` — User registration
+- Line 51: Entire form wrapped in `{% if session['name'] %}` — non-logged-in users see blank page
+
+`templates/ehistoric.html` — Execution history
+- Line 75: Delete link rendered for each execution **without** session check:
+  ```html
+  <a href="./deleconf/{{item[0]}}">Delete</a>
+  ```
+
+`templates/login.html` — Login form
+- No session check (publicly accessible)
+
+**Template Inheritance:**
+- **No base template** — each HTML file is standalone (no `{% extends %}` pattern)
+- No Jinja2 macros for shared UI components
+- Navigation bar and styling repeated in each template independently
+
+---
+
+#### 5. Project/User Relationships
+
+- **No explicit user-project association** — users are global; no membership or team table exists
+- All registered users have equal access to all projects
+- No concept of project ownership, creator tracking, or per-project roles
+- `TB_PROJECT` has no `owner_id` or `created_by` field
+- Test runs in `TB_EXECUTION` have no `created_by` or `user_id` field
+- Any authenticated user can currently view or delete any project or test run
+
+---
+
+#### 6. Soft-Delete / Deleted Run Patterns
+
+**Current Deletion Behavior:**
+- Hard delete only — `DELETE FROM TB_EXECUTION WHERE Execution_Id='%s'` (`app.py:260`)
+- No `is_deleted` column, `deleted_at` timestamp, or `deleted_by` field anywhere in schema
+- Deletion is immediate and permanent
+
+**Current Listing Queries:**
+- Execution history: `SELECT * from TB_EXECUTION order by Execution_Id desc LIMIT 500;` (`app.py:239`)
+- Project list: `SELECT * from TB_PROJECT ORDER BY Project_Name ASC;` (`app.py:12`)
+- All queries assume all rows are "active" — no filtering on deletion state
+
+**Pagination:**
+- Execution history: fixed `LIMIT 500` (`app.py:239`)
+- Dashboard trend: fixed `LIMIT 10` (`app.py:141`)
+- No offset-based pagination — fixed result caps only
+
+**Restoration Capability:** None — no recovery mechanism exists without database-level binary logs.
+
+**Audit Trail:** None — no log of deletion actor, timestamp, or reason.
+
+---
+
+### Code References
+
+| File | Lines | Description |
+|------|-------|-------------|
+| `app.py` | 1-11 | Imports: Flask, bcrypt, mysql.connector, session |
+| `app.py` | 26-34 | `delete_db_conf` / `delete_db` — project deletion routes |
+| `app.py` | 37-66 | Login route — session creation |
+| `app.py` | 47-48 | `session['name']` and `session['email']` assignment |
+| `app.py` | 67 | `session.clear()` on logout |
+| `app.py` | 69-85 | Registration route |
+| `app.py` | 87-146 | Dashboard rendering |
+| `app.py` | 141 | `LIMIT 10` execution trend query |
+| `app.py` | 239 | `LIMIT 500` execution history query |
+| `app.py` | 255-258 | `delete_eid_conf` — deletion confirmation route |
+| `app.py` | 259-274 | `delete_eid` — actual test run deletion + metrics recalc |
+| `app.py` | 632 | Random session secret key generation |
+| `docker/init.sql` | 19 | `accounts.TB_USERS` table definition |
+| `docker/init.sql` | — | `robothistoric.TB_PROJECT` table definition |
+| `docker/init.sql` | — | Per-project `TB_EXECUTION`, `TB_SUITE`, `TB_TEST` definitions |
+| `templates/index.html` | 64-66 | Session-gated nav buttons |
+| `templates/index.html` | 77 | Session-gated project delete button |
+| `templates/ehistoric.html` | 75 | Execution delete link (no session gate) |
+| `templates/register.html` | 51 | Session-gated registration form |
+
+---
+
+### Constraints Discovered
+
+**Authentication & Session:**
+- Flask default session is signed but not encrypted; tamper-resistant but readable client-side
+- Session secret is regenerated on every app restart — all sessions invalidated on redeploy
+- No session expiry or timeout mechanism
+- No CSRF protection on any form or route
+- No `@login_required` decorator or equivalent — all auth enforcement is template-side only
+
+**Database Schema:**
+- No FK constraints defined — referential integrity not enforced at DB level
+- No unique constraint on `email` in `TB_USERS` — duplicate emails can exist
+- Dynamic per-project databases — no centralized schema migration mechanism
+- Schema changes to per-project tables require re-running DDL against every project DB
+
+**SQL Safety:**
+- String interpolation used in DELETE/DROP queries: `"DELETE FROM TB_EXECUTION WHERE Execution_Id='%s';" % eid`
+- Input validation absent on `db` and `eid` URL parameters
+- Direct SQL injection risk via malicious URL parameters
+
+**Deletion Model:**
+- Hard delete only; no transaction wrapping around the three-table delete cascade
+- Metrics recalculation runs after deletion; partial failure leaves metrics stale
+
+---
+
+### Open Questions
+
+1. **Project Ownership Model:** Should Lead role be per-project (only leads of project X can delete in project X) or global (all Leads can delete anywhere)?
+
+2. **Soft-Delete Schema Strategy:** Should `is_deleted` / `deleted_at` / `deleted_by` columns be added to `TB_EXECUTION`, or should a separate audit/tombstone table be created?
+
+3. **Deleted Runs Tab Scope:** Should deleted runs be visible across all projects on one tab, or per-project only (consistent with current project-scoped views)?
+
+4. **Retention Policy:** How long should soft-deleted runs be retained before permanent purge?
+
+5. **Auth Enforcement Layer:** Should route-level protection use a Flask `@login_required`-style decorator, or is session verification inline in each handler sufficient?
+
+6. **Audit Trail Requirement:** Is a `TB_DELETION_LOG` table (actor, target, timestamp) needed, or is the soft-delete row itself sufficient audit?
+
+7. **Per-Project DB Schema Migration:** For soft-delete, who/what runs `ALTER TABLE TB_EXECUTION ADD COLUMN is_deleted...` against every existing project database?

--- a/.context/domains/access-control/research/current/2026-05-12-role-based-deletion-permissions.md
+++ b/.context/domains/access-control/research/current/2026-05-12-role-based-deletion-permissions.md
@@ -4,7 +4,7 @@ author: Neil Howell
 domain: access-control
 jira: QE-7360
 scope: "robotframework_historic/app.py, docker/init.sql, robotframework_historic/templates/"
-status: draft
+status: validated
 ---
 
 # Research: Role-Based Access Control Foundations in RFHistoric
@@ -319,18 +319,18 @@ Table: `TB_TEST`
 
 ---
 
-### Open Questions
+### Decisions (Open Questions Resolved)
 
-1. **Project Ownership Model:** Should Lead role be per-project (only leads of project X can delete in project X) or global (all Leads can delete anywhere)?
+1. **Project Ownership Model:** Lead role is **global** — all Lead users can delete test runs in any project, regardless of which project.
 
-2. **Soft-Delete Schema Strategy:** Should `is_deleted` / `deleted_at` / `deleted_by` columns be added to `TB_EXECUTION`, or should a separate audit/tombstone table be created?
+2. **Soft-Delete Schema Strategy:** Use a **separate `TB_DELETION_LOG` table** per project database (not nullable columns on `TB_EXECUTION`). Keeps the core execution table clean and provides a clear, queryable audit trail. Deeper pros/cons research requested before finalizing schema design.
 
-3. **Deleted Runs Tab Scope:** Should deleted runs be visible across all projects on one tab, or per-project only (consistent with current project-scoped views)?
+3. **Deleted Runs Tab Scope:** **Per-project only** — consistent with the existing project-scoped navigation pattern.
 
-4. **Retention Policy:** How long should soft-deleted runs be retained before permanent purge?
+4. **Retention Policy:** **Retain indefinitely.** Deletion log data is inexpensive to store; cleanup can be handled by a future maintenance script if ever needed. Indefinite retention preserves full audit history and enables potential restoration.
 
-5. **Auth Enforcement Layer:** Should route-level protection use a Flask `@login_required`-style decorator, or is session verification inline in each handler sufficient?
+5. **Auth Enforcement Layer:** **Consistent with existing codebase** — inline session checks in route handlers (matching the pattern already used, extended to server-side rather than template-only).
 
-6. **Audit Trail Requirement:** Is a `TB_DELETION_LOG` table (actor, target, timestamp) needed, or is the soft-delete row itself sufficient audit?
+6. **Audit Trail Requirement:** **Separate `TB_DELETION_LOG` table** — same rationale as #2; provides clear, queryable audit without bloating `TB_EXECUTION`. Deeper research requested before finalizing schema design.
 
-7. **Per-Project DB Schema Migration:** For soft-delete, who/what runs `ALTER TABLE TB_EXECUTION ADD COLUMN is_deleted...` against every existing project database?
+7. **Per-Project DB Schema Migration:** **One-time migration script** — run as part of deployment to `CREATE TABLE TB_DELETION_LOG` in every existing project database discovered via `robothistoric.TB_PROJECT`. 

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -18,12 +18,13 @@ CREATE TABLE IF NOT EXISTS TB_USERS (
     id       INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name     VARCHAR(255),
     email    VARCHAR(255),
-    password VARCHAR(255)
+    password VARCHAR(255),
+    role     VARCHAR(20) NOT NULL DEFAULT 'viewer'
 );
 
 -- Test login: admin@local / admin
-INSERT INTO TB_USERS (name, email, password)
-VALUES ('Admin', 'admin@local', '$2b$12$/3e9h/RIPYK2xIKOoIVXd.mpHrBT4AsWkv8wJYXTrQWJEu4Ah3v8u');
+INSERT INTO TB_USERS (name, email, password, role)
+VALUES ('Admin', 'admin@local', '$2b$12$/3e9h/RIPYK2xIKOoIVXd.mpHrBT4AsWkv8wJYXTrQWJEu4Ah3v8u', 'lead');
 
 USE robothistoric;
 
@@ -124,6 +125,24 @@ VALUES
     (3, 'Search by name', 'FAIL', 2.9, 'Timeout waiting for results'),
     (3, 'Search by tag',  'PASS', 3.0, '');
 
+CREATE TABLE IF NOT EXISTS TB_DELETION_LOG (
+    log_id                    INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id              INT NOT NULL,
+    deleted_at                DATETIME DEFAULT CURRENT_TIMESTAMP,
+    deleted_by                VARCHAR(255),
+    snapshot_execution_date   DATETIME,
+    snapshot_execution_desc   TEXT,
+    snapshot_execution_pass   INT,
+    snapshot_execution_fail   INT,
+    snapshot_execution_total  INT,
+    snapshot_execution_time   FLOAT,
+    snapshot_execution_stotal INT,
+    snapshot_execution_spass  INT,
+    snapshot_execution_sfail  INT,
+    INDEX (execution_id),
+    INDEX (deleted_at)
+);
+
 -- ------------------------------------------------------------
 -- Scenario 2: roomba_sync_data - executions only, no suite/test rows
 -- ------------------------------------------------------------
@@ -179,6 +198,24 @@ VALUES
     (NOW() - INTERVAL 1 DAY, 'Roomba sync run 1', 0, 0, 0, 0.0, 0, 0, 0, 0, 0),
     (NOW(),                  'Roomba sync run 2', 0, 0, 0, 0.0, 0, 0, 0, 0, 0);
 
+CREATE TABLE IF NOT EXISTS TB_DELETION_LOG (
+    log_id                    INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id              INT NOT NULL,
+    deleted_at                DATETIME DEFAULT CURRENT_TIMESTAMP,
+    deleted_by                VARCHAR(255),
+    snapshot_execution_date   DATETIME,
+    snapshot_execution_desc   TEXT,
+    snapshot_execution_pass   INT,
+    snapshot_execution_fail   INT,
+    snapshot_execution_total  INT,
+    snapshot_execution_time   FLOAT,
+    snapshot_execution_stotal INT,
+    snapshot_execution_spass  INT,
+    snapshot_execution_sfail  INT,
+    INDEX (execution_id),
+    INDEX (deleted_at)
+);
+
 -- ------------------------------------------------------------
 -- Scenario 3: empty_project - no data at all (tables exist but are empty)
 -- ------------------------------------------------------------
@@ -226,5 +263,23 @@ CREATE TABLE IF NOT EXISTS TB_TEST (
     Test_Issue_Type  TEXT,
     Test_Tag         TEXT,
     Test_Updated     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS TB_DELETION_LOG (
+    log_id                    INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id              INT NOT NULL,
+    deleted_at                DATETIME DEFAULT CURRENT_TIMESTAMP,
+    deleted_by                VARCHAR(255),
+    snapshot_execution_date   DATETIME,
+    snapshot_execution_desc   TEXT,
+    snapshot_execution_pass   INT,
+    snapshot_execution_fail   INT,
+    snapshot_execution_total  INT,
+    snapshot_execution_time   FLOAT,
+    snapshot_execution_stotal INT,
+    snapshot_execution_spass  INT,
+    snapshot_execution_sfail  INT,
+    INDEX (execution_id),
+    INDEX (deleted_at)
 );
 -- No rows inserted - empty tables

--- a/robotframework_historic/app.py
+++ b/robotframework_historic/app.py
@@ -206,12 +206,28 @@ def ehistoric(db):
 
 @app.route('/<db>/deleconf/<eid>', methods=['GET'])
 def delete_eid_conf(db, eid):
+    if session.get('role') != 'lead':
+        return 'Forbidden', 403
     return render_template('deleconf.html', db_name = db, eid = eid)
 
 @app.route('/<db>/edelete/<eid>', methods=['GET'])
 def delete_eid(db, eid):
+    if session.get('role') != 'lead':
+        return 'Forbidden', 403
     cursor = mysql.connection.cursor()
     use_db(cursor, db)
+    # write audit snapshot before deleting
+    cursor.execute(
+        "INSERT INTO TB_DELETION_LOG "
+        "(execution_id, deleted_by, snapshot_execution_date, snapshot_execution_desc, "
+        "snapshot_execution_pass, snapshot_execution_fail, snapshot_execution_total, "
+        "snapshot_execution_time, snapshot_execution_stotal, snapshot_execution_spass, snapshot_execution_sfail) "
+        "SELECT Execution_Id, %s, Execution_Date, Execution_Desc, "
+        "Execution_Pass, Execution_Fail, Execution_Total, "
+        "Execution_Time, Execution_STotal, Execution_SPass, Execution_SFail "
+        "FROM TB_EXECUTION WHERE Execution_Id=%s",
+        (session.get('email'), eid)
+    )
     # remove execution from tables: execution, suite, test
     cursor.execute("DELETE FROM TB_EXECUTION WHERE Execution_Id='%s';" % eid)
     cursor.execute("DELETE FROM TB_SUITE WHERE Execution_Id='%s';" % eid)

--- a/robotframework_historic/app.py
+++ b/robotframework_historic/app.py
@@ -54,6 +54,7 @@ def login():
             if bcrypt.hashpw(password, user["password"].encode('utf-8')) == user["password"].encode('utf-8'):
                 session['name'] = user['name']
                 session['email'] = user['email']
+                session['role'] = user['role']
                 return redirect(url_for('index'))
             else:
                 return redirect("/login" )
@@ -75,11 +76,12 @@ def register():
         name = request.form['name']
         email = request.form['email']
         password = request.form['password'].encode('utf-8')
+        role = request.form.get('role', 'viewer')
         hash_password = bcrypt.hashpw(password, bcrypt.gensalt())
 
         cur = mysql.connection.cursor()
         use_db(cur, "accounts")
-        cur.execute("INSERT INTO TB_USERS (name, email, password) VALUES (%s,%s,%s)",(name,email,hash_password,))
+        cur.execute("INSERT INTO TB_USERS (name, email, password, role) VALUES (%s,%s,%s,%s)",(name,email,hash_password,role,))
         mysql.connection.commit()
         session['name'] = request.form['name']
         session['email'] = request.form['email']

--- a/robotframework_historic/app.py
+++ b/robotframework_historic/app.py
@@ -27,10 +27,14 @@ def redirect_url():
 
 @app.route('/<db>/deldbconf', methods=['GET'])
 def delete_db_conf(db):
+    if session.get('role') != 'lead':
+        return 'Forbidden', 403
     return render_template('deldbconf.html', db_name = db)
 
 @app.route('/<db>/delete', methods=['GET'])
 def delete_db(db):
+    if session.get('role') != 'lead':
+        return 'Forbidden', 403
     cursor = mysql.connection.cursor()
     cursor.execute("DROP DATABASE %s;" % db)
     # use_db(cursor, "robothistoric")
@@ -203,6 +207,21 @@ def ehistoric(db):
     data = cursor.fetchall()
     data = convert_utc_to_cst(data)
     return render_template('ehistoric.html', data=data, db_name=db)
+
+@app.route('/<db>/deleted', methods=['GET'])
+def deleted_runs(db):
+    cursor = mysql.connection.cursor()
+    use_db(cursor, db)
+    cursor.execute(
+        "SELECT execution_id, deleted_by, deleted_at, "
+        "snapshot_execution_date, snapshot_execution_desc, "
+        "snapshot_execution_total, snapshot_execution_pass, snapshot_execution_fail, "
+        "snapshot_execution_time, snapshot_execution_stotal, "
+        "snapshot_execution_spass, snapshot_execution_sfail "
+        "FROM TB_DELETION_LOG ORDER BY deleted_at DESC"
+    )
+    data = cursor.fetchall()
+    return render_template('deletedhistoric.html', data=data, db_name=db)
 
 @app.route('/<db>/deleconf/<eid>', methods=['GET'])
 def delete_eid_conf(db, eid):

--- a/robotframework_historic/app.py
+++ b/robotframework_historic/app.py
@@ -119,6 +119,21 @@ def add_db():
                            "Test_Comment TEXT, Test_Assigned_To TEXT, Test_ETA TEXT, "
                            "Test_Review_By TEXT, Test_Issue_Type TEXT, Test_Tag TEXT, "
                            "Test_Updated TEXT);")
+            cursor.execute("Create table TB_DELETION_LOG ( log_id INT NOT NULL "
+                           "auto_increment primary key, execution_id INT NOT NULL, "
+                           "deleted_at DATETIME DEFAULT CURRENT_TIMESTAMP, "
+                           "deleted_by VARCHAR(255), "
+                           "snapshot_execution_date DATETIME, "
+                           "snapshot_execution_desc TEXT, "
+                           "snapshot_execution_pass INT, "
+                           "snapshot_execution_fail INT, "
+                           "snapshot_execution_total INT, "
+                           "snapshot_execution_time FLOAT, "
+                           "snapshot_execution_stotal INT, "
+                           "snapshot_execution_spass INT, "
+                           "snapshot_execution_sfail INT, "
+                           "INDEX (execution_id), "
+                           "INDEX (deleted_at));")
             mysql.connection.commit()
         except Exception as e:
             print(str(e))

--- a/robotframework_historic/templates/compare.html
+++ b/robotframework_historic/templates/compare.html
@@ -114,6 +114,7 @@
                     <li class="tablinks"><a href="./search"><i class="fa fa-search"></i> Search</a></li>
                     <li class="tablinks active" onclick="executeDataTable()"><a href="./compare"><i
                                 class="fa fa-sliders"></i> Compare</a></li>
+                    <li class="tablinks"><a href="./deleted"><i class="fa fa-trash"></i> Deleted Runs</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://owaspzaphistoric-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-bug"></i> OWASP ZAP Historic</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://dashboard-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-asterisk"></i> QE Dashboard</a></li>
                 </ul>

--- a/robotframework_historic/templates/dashboard.html
+++ b/robotframework_historic/templates/dashboard.html
@@ -106,6 +106,7 @@
                     <li class="tablinks"><a href="./flaky"><i class="fa fa-bolt"></i> Flaky</a></li>
                     <li class="tablinks"><a href="./search"><i class="fa fa-search"></i> Search</a></li>
                     <li class="tablinks"><a href="./compare"><i class="fa fa-sliders"></i> Compare</a></li>
+                    <li class="tablinks"><a href="./deleted"><i class="fa fa-trash"></i> Deleted Runs</a></li>
 		    		<li class="tablinks" onclick="executeDataTable()"><a href="https://owaspzaphistoric-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-bug"></i> OWASP ZAP Historic</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://dashboard-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-asterisk"></i> QE Dashboard</a></li>
                 </ul>

--- a/robotframework_historic/templates/deleconf.html
+++ b/robotframework_historic/templates/deleconf.html
@@ -55,8 +55,15 @@
             <div id="db-row" class="row justify-content-center align-items-center">
                 <div id="db-column" class="col-md-6">
                     <div id="db-box" class="col-md-12">
-                        <form id="db-form" class="form" action="" method="post">
-                            <h3 class="text-center text-info">Delete Execution?</h3>
+                        <form id="db-form" class="form" action="" method="post">                            {% if session.get('role') != 'lead' %}
+                            <h3 class="text-center text-danger">Insufficient permissions</h3>
+                            <hr>
+                            <p class="text-muted text-center">You do not have permission to delete test runs.</p>
+                            <hr>
+                            <div class="text-center">
+                                <a href="../ehistoric" type="button" class="btn btn-info">Back</a>
+                            </div>
+                            {% else %}                            <h3 class="text-center text-info">Delete Execution?</h3>
 							<hr>
                             <p class="text-muted">Would you like to delete execution: <b style="color:red">{{eid}}</b> ? You cannot undo this.</p>
 							<hr>
@@ -74,6 +81,7 @@
                                     </td>
                                 </tr>
                             <table>
+                            {% endif %}
                         </form>
                     </div>
                 </div>

--- a/robotframework_historic/templates/deletedhistoric.html
+++ b/robotframework_historic/templates/deletedhistoric.html
@@ -3,7 +3,7 @@
 
 <head>
     <link href="https://img.icons8.com/cotton/64/000000/time-machine.png" rel="shortcut icon" type="image/x-icon"/>
-    <title>RF Historic - History</title>
+    <title>RF Historic - Deleted Runs</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
@@ -12,7 +12,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
-      <!-- Bootstrap core Datatable-->
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js" type="text/javascript"></script>
     <script src="https://cdn.datatables.net/buttons/1.5.2/js/dataTables.buttons.min.js" type="text/javascript"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js" type="text/javascript"></script>
@@ -26,13 +25,12 @@
         .dt-buttons {
             margin-left: 5px;
         }
-
         .tablinks .active {
             background-color: #666;
             color: white;
         }
-        th, td{
-            text-align:center;
+        th, td {
+            text-align: center;
         }
     </style>
 </head>
@@ -42,7 +40,7 @@
         window.onload = function(){
             executeDataTable();
         };
-   </script>
+    </script>
     <nav class="navbar navbar-inverse navbar-fixed-top">
         <div class="container-fluid">
             <div class="navbar-header">
@@ -56,14 +54,14 @@
             <div class="collapse navbar-collapse" id="myNavbar">
                 <ul class="nav navbar-nav">
                     <li class="tablinks"><a href="./dashboard"><i class="fa fa-dashboard"></i> Dashboard</a></li>
-                    <li class="tablinks active" onclick="executeDataTable()"><a href="./ehistoric"><i class="fa fa-history"></i> History</a></li>
+                    <li class="tablinks"><a href="./ehistoric"><i class="fa fa-history"></i> History</a></li>
                     <li class="tablinks"><a href="./tmetrics"><i class="fa fa-flask"></i> Metrics</a></li>
                     <li class="tablinks"><a href="./flaky"><i class="fa fa-bolt"></i> Flaky</a></li>
                     <li class="tablinks"><a href="./search"><i class="fa fa-search"></i> Search</a></li>
                     <li class="tablinks"><a href="./compare"><i class="fa fa-sliders"></i> Compare</a></li>
-                    <li class="tablinks"><a href="./deleted"><i class="fa fa-trash"></i> Deleted Runs</a></li>
-                    <li class="tablinks" onclick="executeDataTable()"><a href="https://owaspzaphistoric-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-bug"></i> OWASP ZAP Historic</a></li>
-                    <li class="tablinks" onclick="executeDataTable()"><a href="https://dashboard-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-asterisk"></i> QE Dashboard</a></li>
+                    <li class="tablinks active"><a href="./deleted"><i class="fa fa-trash"></i> Deleted Runs</a></li>
+                    <li class="tablinks"><a href="https://owaspzaphistoric-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-bug"></i> OWASP ZAP Historic</a></li>
+                    <li class="tablinks"><a href="https://dashboard-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-asterisk"></i> QE Dashboard</a></li>
                 </ul>
             </div>
         </div>
@@ -71,13 +69,16 @@
 
     <div class="tabcontent">
         <div class="d-flex flex-column flex-md-row align-items-center p-1 mb-3 bg-light border-bottom shadow-sm">
-            <h3 class="my-0 mr-md-auto font-weight-normal" >{{db_name}} - Recent Executions</h3>
+            <h3 class="my-0 mr-md-auto font-weight-normal">{{db_name}} - Deleted Runs</h3>
         </div>
         <hr>
-        <table class="table table-striped" id="ehist">
+        {% if data %}
+        <table class="table table-striped" id="delhist">
             <thead>
                 <tr>
                     <th>EID</th>
+                    <th>Deleted By</th>
+                    <th>Deleted At</th>
                     <th>Date</th>
                     <th>Description</th>
                     <th>Test Total</th>
@@ -87,94 +88,68 @@
                     <th>Suite Total</th>
                     <th>Suite Pass</th>
                     <th>Suite Fail</th>
-                    <th>Metrics | Failures | Delete</th>
                 </tr>
             </thead>
             <tbody>
                 {% for item in data %}
                     <tr>
-                        <td title="Click to view {{item[0]}} execution info"><a href="./tmetrics/{{item[0]}}" target="_blank">{{item[0]}}</a></td>
-                        <td> {{item[1].strftime('%b %d %Y %I:%M %p %Z')}}</td>
-                        <td style="word-wrap: break-word;max-width: 250px; white-space: normal; text-align: left;"> {{item[2]}}</td>
-                        <td style="color: brown"> {{item[3]}}</td>
-                        <td style="color: green"> {{item[4]}}</td>
-                        <td style="color: red"> {{item[5]}}</td>
-                        <td>{{item[6]}}</td>
-                        <td style="color: brown"> {{item[7]}}</td>
-                        <td style="color: green"> {{item[8]}}</td>
-                        <td style="color: red"> {{item[9]}}</td>
-                        <td> <a href="./metrics/{{item[0]}}" target="_blank">View</a> | <a href="./failures/{{item[0]}}" target="_blank">Failures</a> {% if session.get('role') == 'lead' %} | <a href="./deleconf/{{item[0]}}">Delete</a>{% endif %}</td>
+                        <td>{{item[0]}}</td>
+                        <td>{{item[1]}}</td>
+                        <td>{{item[2]}}</td>
+                        <td>{{item[3]}}</td>
+                        <td style="word-wrap: break-word; max-width: 250px; white-space: normal; text-align: left;">{{item[4]}}</td>
+                        <td style="color: brown">{{item[5]}}</td>
+                        <td style="color: green">{{item[6]}}</td>
+                        <td style="color: red">{{item[7]}}</td>
+                        <td>{{item[8]}}</td>
+                        <td style="color: brown">{{item[9]}}</td>
+                        <td style="color: green">{{item[10]}}</td>
+                        <td style="color: red">{{item[11]}}</td>
                     </tr>
                 {% endfor %}
             </tbody>
         </table>
+        {% else %}
+        <p class="text-muted">No deleted runs for this project.</p>
+        {% endif %}
     </div>
     <script>
         function executeDataTable() {
-            var fileTitle = "ExecutionHistoric";
-            $('#ehist').DataTable(
+            var fileTitle = "DeletedRunsHistoric";
+            {% if data %}
+            $('#delhist').DataTable(
                 {
                     retrieve: true,
-                    "order": [[ 0, "desc" ]],
+                    "order": [[ 2, "desc" ]],
                     dom: 'l<".margin" B>frtip',
                     buttons: [
-                         {
-							extend:    'copyHtml5',
-							text:      '<i class="fa fa-files-o"></i>',
-							titleAttr: 'Copy',
-							exportOptions: {
-								columns: ':visible:not(:last-child)'
-							}
-						},
+                        {
+                            extend:    'copyHtml5',
+                            text:      '<i class="fa fa-files-o"></i>',
+                            titleAttr: 'Copy',
+                        },
                         {
                             extend:    'csvHtml5',
-							text:      '<i class="fa fa-file-text-o"></i>',
-							titleAttr: 'CSV',
-                            filename: function() {
-                                return fileTitle + '-' + new Date().toLocaleString();
-                            },
-							exportOptions: {
-								columns: ':visible:not(:last-child)'
-							}
+                            text:      '<i class="fa fa-file-text-o"></i>',
+                            titleAttr: 'CSV',
+                            title:     fileTitle
                         },
                         {
-                            extend:    'excelHtml5',
-							text:      '<i class="fa fa-file-excel-o"></i>',
-							titleAttr: 'Excel',
-                            filename: function() {
-                                return fileTitle + '-' + new Date().toLocaleString();
-                            },
-							exportOptions: {
-								columns: ':visible:not(:last-child)'
-							}
+                            extend:    'print',
+                            text:      '<i class="fa fa-print"></i>',
+                            titleAttr: 'Print',
+                            title:     fileTitle
                         },
                         {
-							extend:    'print',
-							text:      '<i class="fa fa-print"></i>',
-							titleAttr: 'Print',
-							exportOptions: {
-								columns: ':visible:not(:last-child)',
-                                alignment: 'left',
-							}
-                        },
-						{
-							extend:    'colvis',
-							collectionLayout: 'fixed two-column',
-							text:      '<i class="fa fa-low-vision"></i>',
-							titleAttr: 'Hide Column',
-							exportOptions: {
-								columns: ':visible:not(:last-child)'
-							},
-							postfixButtons: [ 'colvisRestore' ]
-                        },
-                    ],
-					columnDefs: [ {
-						visible: false,
-					} ]
-			   }
+                            extend:    'colvis',
+                            text:      '<i class="fa fa-low-vision"></i>',
+                            titleAttr: 'Column Visibility'
+                        }
+                    ]
+                }
             );
+            {% endif %}
         }
     </script>
 </body>
-
 </html>

--- a/robotframework_historic/templates/ehistoric.html
+++ b/robotframework_historic/templates/ehistoric.html
@@ -102,7 +102,7 @@
                         <td style="color: brown"> {{item[7]}}</td>
                         <td style="color: green"> {{item[8]}}</td>
                         <td style="color: red"> {{item[9]}}</td>
-                        <td> <a href="./metrics/{{item[0]}}" target="_blank">View</a> | <a href="./failures/{{item[0]}}" target="_blank">Failures</a> {% if session.get('role') == 'lead' %}|<a href="./deleconf/{{item[0]}}">Delete</a>{% endif %}</td>
+                        <td> <a href="./metrics/{{item[0]}}" target="_blank">View</a> | <a href="./failures/{{item[0]}}" target="_blank">Failures</a> {% if session.get('role') == 'lead' %} | <a href="./deleconf/{{item[0]}}">Delete</a>{% endif %}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/robotframework_historic/templates/ehistoric.html
+++ b/robotframework_historic/templates/ehistoric.html
@@ -102,7 +102,7 @@
                         <td style="color: brown"> {{item[7]}}</td>
                         <td style="color: green"> {{item[8]}}</td>
                         <td style="color: red"> {{item[9]}}</td>
-                        <td> <a href="./metrics/{{item[0]}}" target="_blank">View</a> | <a href="./failures/{{item[0]}}" target="_blank">Failures</a> |<a href="./deleconf/{{item[0]}}">Delete</a></td>
+                        <td> <a href="./metrics/{{item[0]}}" target="_blank">View</a> | <a href="./failures/{{item[0]}}" target="_blank">Failures</a> {% if session.get('role') == 'lead' %}|<a href="./deleconf/{{item[0]}}">Delete</a>{% endif %}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/robotframework_historic/templates/flaky.html
+++ b/robotframework_historic/templates/flaky.html
@@ -60,6 +60,7 @@
                     <li class="tablinks active" onclick="executeDataTable()"><a href="./flaky"><i class="fa fa-bolt"></i> Flaky</a></li>
                     <li class="tablinks"><a href="./search"><i class="fa fa-search"></i> Search</a></li>
                     <li class="tablinks"><a href="./compare"><i class="fa fa-sliders"></i> Compare</a></li>
+                    <li class="tablinks"><a href="./deleted"><i class="fa fa-trash"></i> Deleted Runs</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://owaspzaphistoric-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-bug"></i> OWASP ZAP Historic</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://dashboard-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-asterisk"></i> QE Dashboard</a></li>
                 </ul>

--- a/robotframework_historic/templates/index.html
+++ b/robotframework_historic/templates/index.html
@@ -89,7 +89,7 @@
                             </table>
                         </div>
                         <div class="card-footer">
-                            {% if session['name'] %}
+                            {% if session.get('role') == 'lead' %}
                             <a type="button" href="{{item[1]}}/deldbconf" class="btn btn-danger float-left btn-sm"><i class="fa fa-trash-o"></i> Delete</a>
                             {% endif %}
                             <a type="button" href="{{item[1]}}/dashboard" class="btn btn-light float-right btn-sm" style="background-color:silver"><i class="fa fa-play"></i> View</a>

--- a/robotframework_historic/templates/register.html
+++ b/robotframework_historic/templates/register.html
@@ -90,7 +90,7 @@
                                     </td>
                                     <td>
                                         <div class="text-right">
-                                            <button id="submit" type="submit" class="btn btn-primary">Login</button>
+                                            <button id="submit" type="submit" class="btn btn-primary">Register</button>
                                         </div>
                                     </td>
                                 </tr>

--- a/robotframework_historic/templates/register.html
+++ b/robotframework_historic/templates/register.html
@@ -74,6 +74,13 @@
                                 <label for="password" class="text-info">Password:</label><br>
                                 <input type="password" name="password" id="password" class="form-control">
                             </div>
+                            <div class="form-group">
+                                <label for="role" class="text-info">Role:</label><br>
+                                <select name="role" id="role" class="form-control">
+                                    <option value="viewer" selected>Viewer</option>
+                                    <option value="lead">Lead</option>
+                                </select>
+                            </div>
                             <table style="width:100%">
                                 <tr>
                                     <td>

--- a/robotframework_historic/templates/search.html
+++ b/robotframework_historic/templates/search.html
@@ -93,6 +93,7 @@
                     <li class="tablinks"><a href="./flaky"><i class="fa fa-bolt"></i> Flaky</a></li>
                     <li class="tablinks active" onclick="executeDataTable()"><a href="./search"><i class="fa fa-search"></i> Search</a></li>
                     <li class="tablinks"><a href="./compare"><i class="fa fa-sliders"></i> Compare</a></li>
+                    <li class="tablinks"><a href="./deleted"><i class="fa fa-trash"></i> Deleted Runs</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://owaspzaphistoric-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-bug"></i> OWASP ZAP Historic</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://dashboard-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-asterisk"></i> QE Dashboard</a></li>
                 </ul>

--- a/robotframework_historic/templates/tmetrics.html
+++ b/robotframework_historic/templates/tmetrics.html
@@ -60,6 +60,7 @@
                     <li class="tablinks"><a href="./flaky"><i class="fa fa-bolt"></i> Flaky</a></li>
                     <li class="tablinks"><a href="./search"><i class="fa fa-search"></i> Search</a></li>
                     <li class="tablinks"><a href="./compare"><i class="fa fa-sliders"></i> Compare</a></li>
+                    <li class="tablinks"><a href="./deleted"><i class="fa fa-trash"></i> Deleted Runs</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://owaspzaphistoric-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-bug"></i> OWASP ZAP Historic</a></li>
                     <li class="tablinks" onclick="executeDataTable()"><a href="https://dashboard-qe-tools.accruentsystems.com/" target="_blank"><i class="fa fa-asterisk"></i> QE Dashboard</a></li>
                 </ul>

--- a/scripts/migrate_qe7360.py
+++ b/scripts/migrate_qe7360.py
@@ -1,0 +1,143 @@
+"""
+migrate_qe7360.py — Idempotent migration for QE-7360 (Role-Based Deletion Permissions)
+
+Changes applied:
+  1. accounts.TB_USERS: add `role VARCHAR(20) NOT NULL DEFAULT 'viewer'` if absent
+  2. accounts.TB_USERS: set role='lead' for the seed admin (admin@local) if still 'viewer'
+  3. Every project DB in robothistoric.TB_PROJECT: CREATE TABLE IF NOT EXISTS TB_DELETION_LOG
+
+Usage:
+    python scripts/migrate_qe7360.py [--host HOST] [--port PORT] [--user USER] [--password PASSWORD]
+
+Defaults match the docker-compose dev environment (root / password / localhost:3306).
+"""
+
+import argparse
+import sys
+
+import MySQLdb
+
+
+TB_DELETION_LOG_DDL = """
+CREATE TABLE IF NOT EXISTS TB_DELETION_LOG (
+    log_id                    INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id              INT          NOT NULL,
+    deleted_at                DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    deleted_by                VARCHAR(255),
+    snapshot_execution_date   DATETIME,
+    snapshot_execution_desc   TEXT,
+    snapshot_execution_pass   INT,
+    snapshot_execution_fail   INT,
+    snapshot_execution_total  INT,
+    snapshot_execution_time   FLOAT,
+    snapshot_execution_stotal INT,
+    snapshot_execution_spass  INT,
+    snapshot_execution_sfail  INT,
+    INDEX (execution_id),
+    INDEX (deleted_at)
+)
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="QE-7360 schema migration")
+    parser.add_argument("--host",     default="localhost")
+    parser.add_argument("--port",     type=int, default=3306)
+    parser.add_argument("--user",     default="root")
+    parser.add_argument("--password", default="password")
+    return parser.parse_args()
+
+
+def get_connection(args):
+    return MySQLdb.connect(
+        host=args.host,
+        port=args.port,
+        user=args.user,
+        passwd=args.password,
+        charset='utf8',
+    )
+
+
+def add_role_column(cursor):
+    """Add role column to accounts.TB_USERS if it does not already exist."""
+    cursor.execute(
+        "SELECT COUNT(*) FROM information_schema.COLUMNS "
+        "WHERE TABLE_SCHEMA = 'accounts' AND TABLE_NAME = 'TB_USERS' AND COLUMN_NAME = 'role'"
+    )
+    (count,) = cursor.fetchone()
+    if count == 0:
+        cursor.execute(
+            "ALTER TABLE accounts.TB_USERS "
+            "ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'viewer'"
+        )
+        print("  [OK] Added role column to accounts.TB_USERS")
+    else:
+        print("  [SKIP] role column already exists on accounts.TB_USERS")
+
+
+def seed_admin_role(cursor):
+    """Promote the seed admin (admin@local) to 'lead' if still on default 'viewer'."""
+    cursor.execute(
+        "UPDATE accounts.TB_USERS SET role = 'lead' "
+        "WHERE email = 'admin@local' AND role = 'viewer'"
+    )
+    if cursor.rowcount:
+        print("  [OK] Set role='lead' for admin@local")
+    else:
+        print("  [SKIP] admin@local already has a non-viewer role (or does not exist)")
+
+
+def add_deletion_log_tables(cursor):
+    """Create TB_DELETION_LOG in every project database listed in robothistoric.TB_PROJECT."""
+    cursor.execute("SELECT Project_Name FROM robothistoric.TB_PROJECT")
+    projects = [row[0] for row in cursor.fetchall()]
+
+    if not projects:
+        print("  [WARN] No projects found in robothistoric.TB_PROJECT — nothing to migrate")
+        return
+
+    for project in projects:
+        cursor.execute("USE `%s`" % project)
+        cursor.execute(TB_DELETION_LOG_DDL)
+        print("  [OK] TB_DELETION_LOG ready in project db: %s" % project)
+
+
+def main():
+    args = parse_args()
+    print("Connecting to MySQL at %s:%d as %s ..." % (args.host, args.port, args.user))
+
+    try:
+        conn = get_connection(args)
+    except MySQLdb.Error as exc:
+        print("ERROR: Could not connect to MySQL: %s" % exc)
+        sys.exit(1)
+
+    cursor = conn.cursor()
+
+    try:
+        print("\n--- Step 1: accounts.TB_USERS role column ---")
+        add_role_column(cursor)
+
+        print("\n--- Step 2: Seed admin role ---")
+        seed_admin_role(cursor)
+
+        conn.commit()
+
+        print("\n--- Step 3: TB_DELETION_LOG in project databases ---")
+        add_deletion_log_tables(cursor)
+
+        conn.commit()
+        print("\nMigration complete.")
+
+    except MySQLdb.Error as exc:
+        conn.rollback()
+        print("ERROR: %s" % exc)
+        sys.exit(1)
+
+    finally:
+        cursor.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_qe7360.py
+++ b/scripts/migrate_qe7360.py
@@ -1,0 +1,142 @@
+"""
+migrate_qe7360.py — Idempotent migration for QE-7360 (Role-Based Deletion Permissions)
+
+Changes applied:
+  1. accounts.TB_USERS: add `role VARCHAR(20) NOT NULL DEFAULT 'viewer'` if absent
+  2. accounts.TB_USERS: set role='lead' for the seed admin (admin@local) if still 'viewer'
+  3. Every project DB in robothistoric.TB_PROJECT: CREATE TABLE IF NOT EXISTS TB_DELETION_LOG
+
+Usage:
+    python scripts/migrate_qe7360.py [--host HOST] [--port PORT] [--user USER] [--password PASSWORD]
+
+Defaults match the docker-compose dev environment (root / password / localhost:3306).
+"""
+
+import argparse
+import sys
+
+import mysql.connector
+
+
+TB_DELETION_LOG_DDL = """
+CREATE TABLE IF NOT EXISTS TB_DELETION_LOG (
+    log_id                    INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id              INT          NOT NULL,
+    deleted_at                DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    deleted_by                VARCHAR(255),
+    snapshot_execution_date   DATETIME,
+    snapshot_execution_desc   TEXT,
+    snapshot_execution_pass   INT,
+    snapshot_execution_fail   INT,
+    snapshot_execution_total  INT,
+    snapshot_execution_time   FLOAT,
+    snapshot_execution_stotal INT,
+    snapshot_execution_spass  INT,
+    snapshot_execution_sfail  INT,
+    INDEX (execution_id),
+    INDEX (deleted_at)
+)
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="QE-7360 schema migration")
+    parser.add_argument("--host",     default="localhost")
+    parser.add_argument("--port",     type=int, default=3306)
+    parser.add_argument("--user",     default="root")
+    parser.add_argument("--password", default="password")
+    return parser.parse_args()
+
+
+def get_connection(args):
+    return mysql.connector.connect(
+        host=args.host,
+        port=args.port,
+        user=args.user,
+        password=args.password,
+    )
+
+
+def add_role_column(cursor):
+    """Add role column to accounts.TB_USERS if it does not already exist."""
+    cursor.execute(
+        "SELECT COUNT(*) FROM information_schema.COLUMNS "
+        "WHERE TABLE_SCHEMA = 'accounts' AND TABLE_NAME = 'TB_USERS' AND COLUMN_NAME = 'role'"
+    )
+    (count,) = cursor.fetchone()
+    if count == 0:
+        cursor.execute(
+            "ALTER TABLE accounts.TB_USERS "
+            "ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'viewer'"
+        )
+        print("  [OK] Added role column to accounts.TB_USERS")
+    else:
+        print("  [SKIP] role column already exists on accounts.TB_USERS")
+
+
+def seed_admin_role(cursor):
+    """Promote the seed admin (admin@local) to 'lead' if still on default 'viewer'."""
+    cursor.execute(
+        "UPDATE accounts.TB_USERS SET role = 'lead' "
+        "WHERE email = 'admin@local' AND role = 'viewer'"
+    )
+    if cursor.rowcount:
+        print("  [OK] Set role='lead' for admin@local")
+    else:
+        print("  [SKIP] admin@local already has a non-viewer role (or does not exist)")
+
+
+def add_deletion_log_tables(cursor):
+    """Create TB_DELETION_LOG in every project database listed in robothistoric.TB_PROJECT."""
+    cursor.execute("SELECT Project_Name FROM robothistoric.TB_PROJECT")
+    projects = [row[0] for row in cursor.fetchall()]
+
+    if not projects:
+        print("  [WARN] No projects found in robothistoric.TB_PROJECT — nothing to migrate")
+        return
+
+    for project in projects:
+        cursor.execute("USE `%s`" % project)
+        cursor.execute(TB_DELETION_LOG_DDL)
+        print("  [OK] TB_DELETION_LOG ready in project db: %s" % project)
+
+
+def main():
+    args = parse_args()
+    print("Connecting to MySQL at %s:%d as %s ..." % (args.host, args.port, args.user))
+
+    try:
+        conn = get_connection(args)
+    except mysql.connector.Error as exc:
+        print("ERROR: Could not connect to MySQL: %s" % exc)
+        sys.exit(1)
+
+    cursor = conn.cursor()
+
+    try:
+        print("\n--- Step 1: accounts.TB_USERS role column ---")
+        add_role_column(cursor)
+
+        print("\n--- Step 2: Seed admin role ---")
+        seed_admin_role(cursor)
+
+        conn.commit()
+
+        print("\n--- Step 3: TB_DELETION_LOG in project databases ---")
+        add_deletion_log_tables(cursor)
+
+        conn.commit()
+        print("\nMigration complete.")
+
+    except mysql.connector.Error as exc:
+        conn.rollback()
+        print("ERROR: %s" % exc)
+        sys.exit(1)
+
+    finally:
+        cursor.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rollback_qe7360.py
+++ b/scripts/rollback_qe7360.py
@@ -1,0 +1,108 @@
+"""
+rollback_qe7360.py — Idempotent rollback for QE-7360 (Role-Based Deletion Permissions)
+
+Reverses the changes made by migrate_qe7360.py:
+  1. accounts.TB_USERS: drop `role` column if present
+  2. Every project DB in robothistoric.TB_PROJECT: DROP TABLE IF EXISTS TB_DELETION_LOG
+
+WARNING: Dropping TB_DELETION_LOG permanently destroys any audit log data.
+         Only run this before the new application code has been deployed, or if you
+         intend to fully revert the QE-7360 feature.
+
+Usage:
+    python scripts/rollback_qe7360.py [--host HOST] [--port PORT] [--user USER] [--password PASSWORD]
+
+Defaults match the docker-compose dev environment (root / password / localhost:3306).
+"""
+
+import argparse
+import sys
+
+import MySQLdb
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="QE-7360 schema rollback")
+    parser.add_argument("--host",     default="localhost")
+    parser.add_argument("--port",     type=int, default=3306)
+    parser.add_argument("--user",     default="root")
+    parser.add_argument("--password", default="password")
+    return parser.parse_args()
+
+
+def get_connection(args):
+    return MySQLdb.connect(
+        host=args.host,
+        port=args.port,
+        user=args.user,
+        passwd=args.password,
+        charset='utf8',
+    )
+
+
+def drop_role_column(cursor):
+    """Drop role column from accounts.TB_USERS if it exists."""
+    cursor.execute(
+        "SELECT COUNT(*) FROM information_schema.COLUMNS "
+        "WHERE TABLE_SCHEMA = 'accounts' AND TABLE_NAME = 'TB_USERS' AND COLUMN_NAME = 'role'"
+    )
+    (count,) = cursor.fetchone()
+    if count:
+        cursor.execute("ALTER TABLE accounts.TB_USERS DROP COLUMN role")
+        print("  [OK] Dropped role column from accounts.TB_USERS")
+    else:
+        print("  [SKIP] role column does not exist on accounts.TB_USERS")
+
+
+def drop_deletion_log_tables(cursor):
+    """Drop TB_DELETION_LOG from every project database listed in robothistoric.TB_PROJECT."""
+    cursor.execute("SELECT Project_Name FROM robothistoric.TB_PROJECT")
+    projects = [row[0] for row in cursor.fetchall()]
+
+    if not projects:
+        print("  [WARN] No projects found in robothistoric.TB_PROJECT — nothing to roll back")
+        return
+
+    for project in projects:
+        cursor.execute("USE `%s`" % project)
+        cursor.execute("DROP TABLE IF EXISTS TB_DELETION_LOG")
+        print("  [OK] Dropped TB_DELETION_LOG from project db: %s" % project)
+
+
+def main():
+    args = parse_args()
+    print("Connecting to MySQL at %s:%d as %s ..." % (args.host, args.port, args.user))
+
+    try:
+        conn = get_connection(args)
+    except MySQLdb.Error as exc:
+        print("ERROR: Could not connect to MySQL: %s" % exc)
+        sys.exit(1)
+
+    cursor = conn.cursor()
+
+    try:
+        print("\n--- Step 1: Drop role column from accounts.TB_USERS ---")
+        drop_role_column(cursor)
+
+        conn.commit()
+
+        print("\n--- Step 2: Drop TB_DELETION_LOG from project databases ---")
+        drop_deletion_log_tables(cursor)
+
+        conn.commit()
+        print("\nRollback complete.")
+
+    except MySQLdb.Error as exc:
+        conn.rollback()
+        print("\nERROR: %s" % exc)
+        print("Rollback aborted — database left in its pre-rollback state.")
+        sys.exit(1)
+
+    finally:
+        cursor.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Implements QE-7360 — role-based access control for test run deletion in RFHistoric, with a full audit log of deleted runs.

## Changes

### Phase 1 — Schema (QE-7368)
- Added \ole\ column (\VARCHAR(20) NOT NULL DEFAULT 'viewer'\) to \TB_USERS\ in \docker/init.sql\
- Added \TB_DELETION_LOG\ table to all seed project databases in \init.sql\ and the \/newdb\ route
- Added idempotent migration script \scripts/migrate_qe7360.py\ for existing installations
- Added idempotent rollback script \scripts/rollback_qe7360.py\

### Phase 2 — Auth Flow (QE-7365)
- Login route: stores \session['role']\ from database
- Register route: accepts \ole\ field (viewer default, lead selectable); fixed submit button label
- Updated \egister.html\ with role dropdown

### Phase 3 — Delete Route Access Control (QE-7366)
- \delete_eid_conf\ and \delete_eid\ routes: 403 if role != lead
- \delete_eid\ route: inserts snapshot row into \TB_DELETION_LOG\ before deleting
- \deleconf.html\: shows permission error for non-leads, confirmation form for leads
- \historic.html\: Delete link gated to \{% if session.get('role') == 'lead' %}\

### Phase 4 — Deleted Runs Audit Log Tab (QE-7367)
- New \GET /<db>/deleted\ route rendering \TB_DELETION_LOG\ ordered newest-first
- New \deletedhistoric.html\ template with full DataTable, empty state, all snapshot columns
- Deleted Runs nav tab added to all 7 project templates (dashboard, ehistoric, deletedhistoric, flaky, search, tmetrics, compare)
- Tab is visible to all users including unauthenticated (transparency/audit intent)

### Regression Fix (caught during Phase 4 verification)
- \index.html\: Project Delete button gated to \session.get('role') == 'lead'\ (was \session['name']\ — any authenticated user could see it)
- \delete_db_conf\ and \delete_db\ routes: added server-side 403 check for Lead role

## Testing
All four phases manually verified. Viewer/Lead role separation confirmed across project deletion, run deletion, and audit log visibility.

## Related
- QE-7360 (parent)
- QE-7368, QE-7365, QE-7366, QE-7367 (phase subtasks)
- QE-7369 (production user audit — follow-on)
- QE-7370 (run migration script on prod — follow-on)